### PR TITLE
feat: implement service detector and port calculator (#7, #8)

### DIFF
--- a/internal/service/calculator.go
+++ b/internal/service/calculator.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/lightfastai/dual/internal/config"
+	"github.com/lightfastai/dual/internal/registry"
+)
+
+// ErrContextNotFound is returned when the context is not found in the registry
+var ErrContextNotFound = fmt.Errorf("context not found in registry")
+
+// ErrServiceNotFound is returned when the service is not found in the config
+var ErrServiceNotFound = fmt.Errorf("service not found in config")
+
+// Calculator handles port calculation logic
+type Calculator struct{}
+
+// NewCalculator creates a new Calculator
+func NewCalculator() *Calculator {
+	return &Calculator{}
+}
+
+// CalculatePort calculates the port for a given service in a context
+// Formula: port = basePort + serviceIndex + 1
+// where serviceIndex is the 0-based index of the service in config.Services (ordered alphabetically)
+func (c *Calculator) CalculatePort(cfg *config.Config, reg *registry.Registry, projectPath, contextName, serviceName string) (int, error) {
+	// Get the context from the registry
+	ctx, err := reg.GetContext(projectPath, contextName)
+	if err != nil {
+		if err == registry.ErrContextNotFound || err == registry.ErrProjectNotFound {
+			return 0, ErrContextNotFound
+		}
+		return 0, fmt.Errorf("failed to get context: %w", err)
+	}
+
+	// Check if the service exists in the config
+	if _, exists := cfg.Services[serviceName]; !exists {
+		return 0, ErrServiceNotFound
+	}
+
+	// Get the service index (services are ordered alphabetically for determinism)
+	serviceIndex := c.getServiceIndex(cfg, serviceName)
+
+	// Calculate port: basePort + serviceIndex + 1
+	port := ctx.BasePort + serviceIndex + 1
+
+	return port, nil
+}
+
+// getServiceIndex returns the 0-based index of a service in the config
+// Services are sorted alphabetically to ensure deterministic ordering
+func (c *Calculator) getServiceIndex(cfg *config.Config, serviceName string) int {
+	// Get all service names and sort them alphabetically
+	serviceNames := make([]string, 0, len(cfg.Services))
+	for name := range cfg.Services {
+		serviceNames = append(serviceNames, name)
+	}
+	sort.Strings(serviceNames)
+
+	// Find the index of the target service
+	for i, name := range serviceNames {
+		if name == serviceName {
+			return i
+		}
+	}
+
+	// Should never reach here if service exists in config
+	return -1
+}
+
+// GetServiceIndex is a helper function that returns the service index without needing a Calculator instance
+func GetServiceIndex(cfg *config.Config, serviceName string) int {
+	calc := NewCalculator()
+	return calc.getServiceIndex(cfg, serviceName)
+}
+
+// CalculatePort is a convenience function that creates a calculator and calculates the port
+func CalculatePort(cfg *config.Config, reg *registry.Registry, projectPath, contextName, serviceName string) (int, error) {
+	calc := NewCalculator()
+	return calc.CalculatePort(cfg, reg, projectPath, contextName, serviceName)
+}
+
+// CalculateAllPorts returns a map of all service names to their calculated ports for a given context
+func CalculateAllPorts(cfg *config.Config, reg *registry.Registry, projectPath, contextName string) (map[string]int, error) {
+	// Get the context to ensure it exists
+	ctx, err := reg.GetContext(projectPath, contextName)
+	if err != nil {
+		if err == registry.ErrContextNotFound || err == registry.ErrProjectNotFound {
+			return nil, ErrContextNotFound
+		}
+		return nil, fmt.Errorf("failed to get context: %w", err)
+	}
+
+	// Get sorted service names
+	serviceNames := make([]string, 0, len(cfg.Services))
+	for name := range cfg.Services {
+		serviceNames = append(serviceNames, name)
+	}
+	sort.Strings(serviceNames)
+
+	// Calculate port for each service
+	ports := make(map[string]int)
+	for i, name := range serviceNames {
+		ports[name] = ctx.BasePort + i + 1
+	}
+
+	return ports, nil
+}

--- a/internal/service/calculator_test.go
+++ b/internal/service/calculator_test.go
@@ -1,0 +1,586 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightfastai/dual/internal/config"
+	"github.com/lightfastai/dual/internal/registry"
+)
+
+// createTestRegistry creates a registry with test data
+func createTestRegistry() *registry.Registry {
+	reg := &registry.Registry{
+		Projects: map[string]registry.Project{
+			"/project": {
+				Contexts: map[string]registry.Context{
+					"main": {
+						BasePort: 4100,
+						Created:  time.Now(),
+					},
+					"feature": {
+						BasePort: 4200,
+						Created:  time.Now(),
+					},
+					"develop": {
+						BasePort: 4300,
+						Created:  time.Now(),
+					},
+				},
+			},
+			"/other-project": {
+				Contexts: map[string]registry.Context{
+					"main": {
+						BasePort: 5000,
+						Created:  time.Now(),
+					},
+				},
+			},
+		},
+	}
+	return reg
+}
+
+// createTestConfig creates a config with test services
+func createTestConfig() *config.Config {
+	return &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"web": {
+				Path:    "apps/web",
+				EnvFile: ".env.local",
+			},
+			"api": {
+				Path:    "apps/api",
+				EnvFile: ".env.local",
+			},
+			"worker": {
+				Path: "apps/worker",
+			},
+		},
+	}
+}
+
+// TestCalculatePort_BasicCalculation tests basic port calculation
+func TestCalculatePort_BasicCalculation(t *testing.T) {
+	cfg := createTestConfig()
+	reg := createTestRegistry()
+	calc := NewCalculator()
+
+	tests := []struct {
+		name        string
+		projectPath string
+		contextName string
+		serviceName string
+		expected    int
+		wantErr     bool
+	}{
+		{
+			name:        "web service - main context",
+			projectPath: "/project",
+			contextName: "main",
+			serviceName: "web",
+			expected:    4102, // basePort 4100 + index 1 (alphabetically: api=0, web=1, worker=2) + 1
+			wantErr:     false,
+		},
+		{
+			name:        "api service - main context",
+			projectPath: "/project",
+			contextName: "main",
+			serviceName: "api",
+			expected:    4101, // basePort 4100 + index 0 + 1
+			wantErr:     false,
+		},
+		{
+			name:        "worker service - main context",
+			projectPath: "/project",
+			contextName: "main",
+			serviceName: "worker",
+			expected:    4103, // basePort 4100 + index 2 + 1
+			wantErr:     false,
+		},
+		{
+			name:        "web service - feature context",
+			projectPath: "/project",
+			contextName: "feature",
+			serviceName: "web",
+			expected:    4202, // basePort 4200 + index 1 + 1
+			wantErr:     false,
+		},
+		{
+			name:        "api service - develop context",
+			projectPath: "/project",
+			contextName: "develop",
+			serviceName: "api",
+			expected:    4301, // basePort 4300 + index 0 + 1
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, err := calc.CalculatePort(cfg, reg, tt.projectPath, tt.contextName, tt.serviceName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got port: %d", port)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if port != tt.expected {
+					t.Errorf("expected port %d, got %d", tt.expected, port)
+				}
+			}
+		})
+	}
+}
+
+// TestCalculatePort_ErrorHandling tests error cases
+func TestCalculatePort_ErrorHandling(t *testing.T) {
+	cfg := createTestConfig()
+	reg := createTestRegistry()
+	calc := NewCalculator()
+
+	tests := []struct {
+		name        string
+		projectPath string
+		contextName string
+		serviceName string
+		expectedErr error
+	}{
+		{
+			name:        "context not found",
+			projectPath: "/project",
+			contextName: "nonexistent",
+			serviceName: "web",
+			expectedErr: ErrContextNotFound,
+		},
+		{
+			name:        "project not found",
+			projectPath: "/nonexistent",
+			contextName: "main",
+			serviceName: "web",
+			expectedErr: ErrContextNotFound,
+		},
+		{
+			name:        "service not found",
+			projectPath: "/project",
+			contextName: "main",
+			serviceName: "nonexistent",
+			expectedErr: ErrServiceNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := calc.CalculatePort(cfg, reg, tt.projectPath, tt.contextName, tt.serviceName)
+
+			if err != tt.expectedErr {
+				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			}
+		})
+	}
+}
+
+// TestCalculatePort_DifferentProjects tests calculation across different projects
+func TestCalculatePort_DifferentProjects(t *testing.T) {
+	cfg := createTestConfig()
+	reg := createTestRegistry()
+	calc := NewCalculator()
+
+	// Same service, different projects should have different ports
+	port1, err := calc.CalculatePort(cfg, reg, "/project", "main", "api")
+	if err != nil {
+		t.Fatalf("unexpected error for project 1: %v", err)
+	}
+
+	port2, err := calc.CalculatePort(cfg, reg, "/other-project", "main", "api")
+	if err != nil {
+		t.Fatalf("unexpected error for project 2: %v", err)
+	}
+
+	if port1 == port2 {
+		t.Errorf("expected different ports for different projects, both got %d", port1)
+	}
+
+	// Verify the actual values
+	if port1 != 4101 {
+		t.Errorf("expected port 4101 for /project, got %d", port1)
+	}
+	if port2 != 5001 {
+		t.Errorf("expected port 5001 for /other-project, got %d", port2)
+	}
+}
+
+// TestGetServiceIndex tests the service index calculation
+func TestGetServiceIndex(t *testing.T) {
+	cfg := createTestConfig()
+	calc := NewCalculator()
+
+	tests := []struct {
+		serviceName string
+		expected    int
+	}{
+		{"api", 0},    // First alphabetically
+		{"web", 1},    // Second alphabetically
+		{"worker", 2}, // Third alphabetically
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.serviceName, func(t *testing.T) {
+			index := calc.getServiceIndex(cfg, tt.serviceName)
+			if index != tt.expected {
+				t.Errorf("expected index %d for %s, got %d", tt.expected, tt.serviceName, index)
+			}
+		})
+	}
+}
+
+// TestGetServiceIndex_Nonexistent tests index for nonexistent service
+func TestGetServiceIndex_Nonexistent(t *testing.T) {
+	cfg := createTestConfig()
+	calc := NewCalculator()
+
+	index := calc.getServiceIndex(cfg, "nonexistent")
+	if index != -1 {
+		t.Errorf("expected -1 for nonexistent service, got %d", index)
+	}
+}
+
+// TestGetServiceIndex_AlphabeticalOrdering tests that services are ordered alphabetically
+func TestGetServiceIndex_AlphabeticalOrdering(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"zebra":   {Path: "zebra"},
+			"alpha":   {Path: "alpha"},
+			"charlie": {Path: "charlie"},
+			"bravo":   {Path: "bravo"},
+		},
+	}
+
+	calc := NewCalculator()
+
+	expected := map[string]int{
+		"alpha":   0,
+		"bravo":   1,
+		"charlie": 2,
+		"zebra":   3,
+	}
+
+	for serviceName, expectedIndex := range expected {
+		index := calc.getServiceIndex(cfg, serviceName)
+		if index != expectedIndex {
+			t.Errorf("expected index %d for %s, got %d", expectedIndex, serviceName, index)
+		}
+	}
+}
+
+// TestCalculatePort_PortFormula tests that the formula port = basePort + serviceIndex + 1 is correct
+func TestCalculatePort_PortFormula(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"service-a": {Path: "a"},
+			"service-b": {Path: "b"},
+			"service-c": {Path: "c"},
+		},
+	}
+
+	reg := &registry.Registry{
+		Projects: map[string]registry.Project{
+			"/test": {
+				Contexts: map[string]registry.Context{
+					"test": {
+						BasePort: 3000,
+						Created:  time.Now(),
+					},
+				},
+			},
+		},
+	}
+
+	calc := NewCalculator()
+
+	tests := []struct {
+		serviceName  string
+		expectedPort int
+	}{
+		// Alphabetically: service-a (index 0), service-b (index 1), service-c (index 2)
+		{"service-a", 3001}, // 3000 + 0 + 1
+		{"service-b", 3002}, // 3000 + 1 + 1
+		{"service-c", 3003}, // 3000 + 2 + 1
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.serviceName, func(t *testing.T) {
+			port, err := calc.CalculatePort(cfg, reg, "/test", "test", tt.serviceName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if port != tt.expectedPort {
+				t.Errorf("expected port %d, got %d", tt.expectedPort, port)
+			}
+		})
+	}
+}
+
+// TestCalculatePort_ConvenienceFunction tests the package-level convenience function
+func TestCalculatePort_ConvenienceFunction(t *testing.T) {
+	cfg := createTestConfig()
+	reg := createTestRegistry()
+
+	port, err := CalculatePort(cfg, reg, "/project", "main", "api")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := 4101
+	if port != expected {
+		t.Errorf("expected port %d, got %d", expected, port)
+	}
+}
+
+// TestGetServiceIndex_HelperFunction tests the package-level helper function
+func TestGetServiceIndex_HelperFunction(t *testing.T) {
+	cfg := createTestConfig()
+
+	index := GetServiceIndex(cfg, "api")
+	if index != 0 {
+		t.Errorf("expected index 0, got %d", index)
+	}
+}
+
+// TestCalculateAllPorts tests calculating ports for all services
+func TestCalculateAllPorts(t *testing.T) {
+	cfg := createTestConfig()
+	reg := createTestRegistry()
+
+	ports, err := CalculateAllPorts(cfg, reg, "/project", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := map[string]int{
+		"api":    4101, // basePort 4100 + 0 + 1
+		"web":    4102, // basePort 4100 + 1 + 1
+		"worker": 4103, // basePort 4100 + 2 + 1
+	}
+
+	if len(ports) != len(expected) {
+		t.Errorf("expected %d ports, got %d", len(expected), len(ports))
+	}
+
+	for serviceName, expectedPort := range expected {
+		actualPort, exists := ports[serviceName]
+		if !exists {
+			t.Errorf("expected port for service %s, not found", serviceName)
+			continue
+		}
+		if actualPort != expectedPort {
+			t.Errorf("service %s: expected port %d, got %d", serviceName, expectedPort, actualPort)
+		}
+	}
+}
+
+// TestCalculateAllPorts_ErrorHandling tests error handling for CalculateAllPorts
+func TestCalculateAllPorts_ErrorHandling(t *testing.T) {
+	cfg := createTestConfig()
+	reg := createTestRegistry()
+
+	tests := []struct {
+		name        string
+		projectPath string
+		contextName string
+		expectedErr error
+	}{
+		{
+			name:        "context not found",
+			projectPath: "/project",
+			contextName: "nonexistent",
+			expectedErr: ErrContextNotFound,
+		},
+		{
+			name:        "project not found",
+			projectPath: "/nonexistent",
+			contextName: "main",
+			expectedErr: ErrContextNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := CalculateAllPorts(cfg, reg, tt.projectPath, tt.contextName)
+			if err != tt.expectedErr {
+				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			}
+		})
+	}
+}
+
+// TestCalculateAllPorts_DifferentContexts tests that different contexts produce different ports
+func TestCalculateAllPorts_DifferentContexts(t *testing.T) {
+	cfg := createTestConfig()
+	reg := createTestRegistry()
+
+	mainPorts, err := CalculateAllPorts(cfg, reg, "/project", "main")
+	if err != nil {
+		t.Fatalf("unexpected error for main context: %v", err)
+	}
+
+	featurePorts, err := CalculateAllPorts(cfg, reg, "/project", "feature")
+	if err != nil {
+		t.Fatalf("unexpected error for feature context: %v", err)
+	}
+
+	// Check that all services have different ports between contexts
+	for serviceName, mainPort := range mainPorts {
+		featurePort, exists := featurePorts[serviceName]
+		if !exists {
+			t.Errorf("service %s not found in feature context", serviceName)
+			continue
+		}
+		if mainPort == featurePort {
+			t.Errorf("service %s has same port %d in both contexts", serviceName, mainPort)
+		}
+	}
+}
+
+// TestCalculatePort_Determinism tests that port calculation is deterministic
+func TestCalculatePort_Determinism(t *testing.T) {
+	cfg := createTestConfig()
+	reg := createTestRegistry()
+	calc := NewCalculator()
+
+	// Calculate the same port multiple times
+	const iterations = 10
+	var ports []int
+
+	for i := 0; i < iterations; i++ {
+		port, err := calc.CalculatePort(cfg, reg, "/project", "main", "web")
+		if err != nil {
+			t.Fatalf("unexpected error on iteration %d: %v", i, err)
+		}
+		ports = append(ports, port)
+	}
+
+	// All ports should be identical
+	firstPort := ports[0]
+	for i, port := range ports {
+		if port != firstPort {
+			t.Errorf("iteration %d: expected port %d, got %d (determinism failed)", i, firstPort, port)
+		}
+	}
+}
+
+// TestCalculatePort_SingleService tests calculation with only one service
+func TestCalculatePort_SingleService(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"app": {Path: "app"},
+		},
+	}
+
+	reg := &registry.Registry{
+		Projects: map[string]registry.Project{
+			"/single": {
+				Contexts: map[string]registry.Context{
+					"main": {
+						BasePort: 8000,
+						Created:  time.Now(),
+					},
+				},
+			},
+		},
+	}
+
+	calc := NewCalculator()
+	port, err := calc.CalculatePort(cfg, reg, "/single", "main", "app")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := 8001 // 8000 + 0 + 1
+	if port != expected {
+		t.Errorf("expected port %d, got %d", expected, port)
+	}
+}
+
+// TestCalculatePort_ManyServices tests calculation with many services
+func TestCalculatePort_ManyServices(t *testing.T) {
+	// Create config with 10 services
+	services := make(map[string]config.Service)
+	for i := 0; i < 10; i++ {
+		name := string(rune('a' + i))
+		services[name] = config.Service{Path: name}
+	}
+
+	cfg := &config.Config{
+		Version:  1,
+		Services: services,
+	}
+
+	reg := &registry.Registry{
+		Projects: map[string]registry.Project{
+			"/many": {
+				Contexts: map[string]registry.Context{
+					"main": {
+						BasePort: 6000,
+						Created:  time.Now(),
+					},
+				},
+			},
+		},
+	}
+
+	calc := NewCalculator()
+
+	// Verify each service gets the correct port
+	expectedPorts := map[string]int{
+		"a": 6001, "b": 6002, "c": 6003, "d": 6004, "e": 6005,
+		"f": 6006, "g": 6007, "h": 6008, "i": 6009, "j": 6010,
+	}
+
+	for serviceName, expectedPort := range expectedPorts {
+		port, err := calc.CalculatePort(cfg, reg, "/many", "main", serviceName)
+		if err != nil {
+			t.Fatalf("unexpected error for service %s: %v", serviceName, err)
+		}
+		if port != expectedPort {
+			t.Errorf("service %s: expected port %d, got %d", serviceName, expectedPort, port)
+		}
+	}
+}
+
+// TestCalculateAllPorts_EmptyServices tests behavior with no services (edge case)
+func TestCalculateAllPorts_EmptyServices(t *testing.T) {
+	cfg := &config.Config{
+		Version:  1,
+		Services: map[string]config.Service{},
+	}
+
+	reg := &registry.Registry{
+		Projects: map[string]registry.Project{
+			"/empty": {
+				Contexts: map[string]registry.Context{
+					"main": {
+						BasePort: 7000,
+						Created:  time.Now(),
+					},
+				},
+			},
+		},
+	}
+
+	ports, err := CalculateAllPorts(cfg, reg, "/empty", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(ports) != 0 {
+		t.Errorf("expected empty ports map, got %d entries", len(ports))
+	}
+}

--- a/internal/service/detector.go
+++ b/internal/service/detector.go
@@ -1,0 +1,194 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/lightfastai/dual/internal/config"
+)
+
+// ErrServiceNotDetected is returned when no service matches the current working directory
+var ErrServiceNotDetected = fmt.Errorf("no service detected for current directory")
+
+// ErrProjectRootNotFound is returned when the project root cannot be determined
+var ErrProjectRootNotFound = fmt.Errorf("project root not found")
+
+// Detector handles service detection logic
+type Detector struct {
+	// gitCommand allows for dependency injection in tests
+	gitCommand func(args ...string) (string, error)
+	// getwd allows for dependency injection in tests
+	getwd func() (string, error)
+	// evalSymlinks allows for dependency injection in tests
+	evalSymlinks func(path string) (string, error)
+}
+
+// NewDetector creates a new Detector with default implementations
+func NewDetector() *Detector {
+	return &Detector{
+		gitCommand:   execGitCommand,
+		getwd:        os.Getwd,
+		evalSymlinks: filepath.EvalSymlinks,
+	}
+}
+
+// DetectService detects which service the current working directory belongs to
+// It returns the service name and the project root path, or an error if no service matches
+func (d *Detector) DetectService(cfg *config.Config, projectRoot string) (string, error) {
+	// Get current working directory
+	cwd, err := d.getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Resolve symlinks in both cwd and project root
+	resolvedCwd, err := d.evalSymlinks(cwd)
+	if err != nil {
+		// If symlink resolution fails, use the original path
+		resolvedCwd = cwd
+	}
+
+	resolvedProjectRoot, err := d.evalSymlinks(projectRoot)
+	if err != nil {
+		// If symlink resolution fails, use the original path
+		resolvedProjectRoot = projectRoot
+	}
+
+	// Convert all service paths to absolute and resolve symlinks
+	servicePaths := make(map[string]string)
+	for name, service := range cfg.Services {
+		// Join with project root to make absolute
+		absPath := filepath.Join(resolvedProjectRoot, service.Path)
+
+		// Resolve symlinks
+		resolvedPath, err := d.evalSymlinks(absPath)
+		if err != nil {
+			// If resolution fails, use the absolute path
+			resolvedPath = absPath
+		}
+
+		// Clean the path to normalize it
+		servicePaths[name] = filepath.Clean(resolvedPath)
+	}
+
+	// Check if CWD is within any service path
+	// We need to find the longest matching path for nested structures
+	var longestMatch string
+	var longestMatchLen int
+
+	for name, servicePath := range servicePaths {
+		// Check if CWD is within this service path
+		if isWithinPath(resolvedCwd, servicePath) {
+			matchLen := len(servicePath)
+			if matchLen > longestMatchLen {
+				longestMatch = name
+				longestMatchLen = matchLen
+			}
+		}
+	}
+
+	if longestMatch == "" {
+		return "", ErrServiceNotDetected
+	}
+
+	return longestMatch, nil
+}
+
+// FindProjectRoot attempts to find the project root using git or by walking up the directory tree
+func (d *Detector) FindProjectRoot() (string, error) {
+	// Try git first
+	output, err := d.gitCommand("rev-parse", "--show-toplevel")
+	if err == nil {
+		projectRoot := strings.TrimSpace(output)
+		if projectRoot != "" {
+			// Resolve symlinks for consistency
+			resolved, err := d.evalSymlinks(projectRoot)
+			if err != nil {
+				return projectRoot, nil
+			}
+			return resolved, nil
+		}
+	}
+
+	// Fallback: walk up directory tree looking for dual.config.yml
+	cwd, err := d.getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	currentDir := cwd
+	for {
+		configPath := filepath.Join(currentDir, config.ConfigFileName)
+		if _, err := os.Stat(configPath); err == nil {
+			// Found the config file
+			resolved, err := d.evalSymlinks(currentDir)
+			if err != nil {
+				return currentDir, nil
+			}
+			return resolved, nil
+		}
+
+		// Move up one directory
+		parent := filepath.Dir(currentDir)
+		if parent == currentDir {
+			// Reached the root without finding config
+			break
+		}
+		currentDir = parent
+	}
+
+	return "", ErrProjectRootNotFound
+}
+
+// isWithinPath checks if targetPath is within or equal to basePath
+func isWithinPath(targetPath, basePath string) bool {
+	// Clean both paths
+	target := filepath.Clean(targetPath)
+	base := filepath.Clean(basePath)
+
+	// Exact match
+	if target == base {
+		return true
+	}
+
+	// Check if target starts with base + separator
+	// This ensures we don't match "/app" with "/application"
+	baseWithSep := base + string(filepath.Separator)
+	return strings.HasPrefix(target+string(filepath.Separator), baseWithSep)
+}
+
+// execGitCommand executes a git command and returns the output
+func execGitCommand(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+// DetectService is a convenience function that creates a detector and detects the service
+// It also attempts to find the project root automatically
+func DetectService(cfg *config.Config, projectRoot string) (string, error) {
+	detector := NewDetector()
+	return detector.DetectService(cfg, projectRoot)
+}
+
+// DetectServiceWithRoot is a convenience function that finds the project root and detects the service
+func DetectServiceWithRoot(cfg *config.Config) (string, string, error) {
+	detector := NewDetector()
+	projectRoot, err := detector.FindProjectRoot()
+	if err != nil {
+		return "", "", err
+	}
+
+	serviceName, err := detector.DetectService(cfg, projectRoot)
+	if err != nil {
+		return "", projectRoot, err
+	}
+
+	return serviceName, projectRoot, nil
+}

--- a/internal/service/detector_test.go
+++ b/internal/service/detector_test.go
@@ -1,0 +1,578 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lightfastai/dual/internal/config"
+)
+
+// Test helper functions
+
+// mockGitCommand creates a mock git command function
+func mockGitCommand(output string, err error) func(args ...string) (string, error) {
+	return func(args ...string) (string, error) {
+		return output, err
+	}
+}
+
+// mockGetwd creates a mock getwd function
+func mockGetwd(dir string, err error) func() (string, error) {
+	return func() (string, error) {
+		return dir, err
+	}
+}
+
+// mockEvalSymlinks creates a mock evalSymlinks function
+func mockEvalSymlinks(mapping map[string]string) func(path string) (string, error) {
+	return func(path string) (string, error) {
+		if resolved, ok := mapping[path]; ok {
+			return resolved, nil
+		}
+		// Default: return the path as-is
+		return path, nil
+	}
+}
+
+// TestDetectService_BasicMatching tests basic service detection
+func TestDetectService_BasicMatching(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"web": {Path: "apps/web"},
+			"api": {Path: "apps/api"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		cwd         string
+		projectRoot string
+		expected    string
+		wantErr     bool
+	}{
+		{
+			name:        "exact match web",
+			cwd:         "/project/apps/web",
+			projectRoot: "/project",
+			expected:    "web",
+			wantErr:     false,
+		},
+		{
+			name:        "exact match api",
+			cwd:         "/project/apps/api",
+			projectRoot: "/project",
+			expected:    "api",
+			wantErr:     false,
+		},
+		{
+			name:        "nested in web",
+			cwd:         "/project/apps/web/src/components",
+			projectRoot: "/project",
+			expected:    "web",
+			wantErr:     false,
+		},
+		{
+			name:        "nested in api",
+			cwd:         "/project/apps/api/routes",
+			projectRoot: "/project",
+			expected:    "api",
+			wantErr:     false,
+		},
+		{
+			name:        "outside all services",
+			cwd:         "/project/scripts",
+			projectRoot: "/project",
+			expected:    "",
+			wantErr:     true,
+		},
+		{
+			name:        "completely outside project",
+			cwd:         "/other/project",
+			projectRoot: "/project",
+			expected:    "",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := &Detector{
+				gitCommand:   mockGitCommand("", fmt.Errorf("not used")),
+				getwd:        mockGetwd(tt.cwd, nil),
+				evalSymlinks: mockEvalSymlinks(map[string]string{}),
+			}
+
+			result, err := detector.DetectService(cfg, tt.projectRoot)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got result: %q", result)
+				}
+				if err != ErrServiceNotDetected {
+					t.Errorf("expected ErrServiceNotDetected, got: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("expected %q, got %q", tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
+// TestDetectService_NestedServices tests that longest match wins for nested services
+func TestDetectService_NestedServices(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"parent": {Path: "apps"},
+			"child":  {Path: "apps/web"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		cwd         string
+		projectRoot string
+		expected    string
+	}{
+		{
+			name:        "in parent only",
+			cwd:         "/project/apps/other",
+			projectRoot: "/project",
+			expected:    "parent",
+		},
+		{
+			name:        "in child - should match child (longest path)",
+			cwd:         "/project/apps/web",
+			projectRoot: "/project",
+			expected:    "child",
+		},
+		{
+			name:        "nested in child",
+			cwd:         "/project/apps/web/src",
+			projectRoot: "/project",
+			expected:    "child",
+		},
+		{
+			name:        "exact match parent",
+			cwd:         "/project/apps",
+			projectRoot: "/project",
+			expected:    "parent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := &Detector{
+				gitCommand:   mockGitCommand("", fmt.Errorf("not used")),
+				getwd:        mockGetwd(tt.cwd, nil),
+				evalSymlinks: mockEvalSymlinks(map[string]string{}),
+			}
+
+			result, err := detector.DetectService(cfg, tt.projectRoot)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestDetectService_SymlinkResolution tests that symlinks are properly resolved
+func TestDetectService_SymlinkResolution(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"web": {Path: "apps/web"},
+		},
+	}
+
+	// Simulate symlink resolution
+	symlinkMap := map[string]string{
+		"/project":          "/real/project",
+		"/symlink/location": "/real/project/apps/web",
+	}
+
+	detector := &Detector{
+		gitCommand:   mockGitCommand("", fmt.Errorf("not used")),
+		getwd:        mockGetwd("/symlink/location", nil),
+		evalSymlinks: mockEvalSymlinks(symlinkMap),
+	}
+
+	result, err := detector.DetectService(cfg, "/project")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "web"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+// TestDetectService_ErrorHandling tests error handling
+func TestDetectService_ErrorHandling(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"web": {Path: "apps/web"},
+		},
+	}
+
+	t.Run("getwd error", func(t *testing.T) {
+		detector := &Detector{
+			gitCommand:   mockGitCommand("", fmt.Errorf("not used")),
+			getwd:        mockGetwd("", fmt.Errorf("permission denied")),
+			evalSymlinks: mockEvalSymlinks(map[string]string{}),
+		}
+
+		_, err := detector.DetectService(cfg, "/project")
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("no service matches", func(t *testing.T) {
+		detector := &Detector{
+			gitCommand:   mockGitCommand("", fmt.Errorf("not used")),
+			getwd:        mockGetwd("/project/other", nil),
+			evalSymlinks: mockEvalSymlinks(map[string]string{}),
+		}
+
+		_, err := detector.DetectService(cfg, "/project")
+		if err != ErrServiceNotDetected {
+			t.Errorf("expected ErrServiceNotDetected, got: %v", err)
+		}
+	})
+}
+
+// TestDetectService_RelativePaths tests handling of relative service paths
+func TestDetectService_RelativePaths(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"web": {Path: "./apps/web"},
+			"api": {Path: "apps/api"},
+		},
+	}
+
+	detector := &Detector{
+		gitCommand:   mockGitCommand("", fmt.Errorf("not used")),
+		getwd:        mockGetwd("/project/apps/web/src", nil),
+		evalSymlinks: mockEvalSymlinks(map[string]string{}),
+	}
+
+	result, err := detector.DetectService(cfg, "/project")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "web"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+// TestFindProjectRoot tests project root detection
+func TestFindProjectRoot(t *testing.T) {
+	tests := []struct {
+		name        string
+		gitOutput   string
+		gitError    error
+		cwd         string
+		expected    string
+		wantErr     bool
+	}{
+		{
+			name:      "git repo - success",
+			gitOutput: "/project/path\n",
+			gitError:  nil,
+			cwd:       "/project/path/subdir",
+			expected:  "/project/path",
+			wantErr:   false,
+		},
+		{
+			name:      "git repo - with whitespace",
+			gitOutput: "  /project/path  \n",
+			gitError:  nil,
+			cwd:       "/project/path",
+			expected:  "/project/path",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := &Detector{
+				gitCommand:   mockGitCommand(tt.gitOutput, tt.gitError),
+				getwd:        mockGetwd(tt.cwd, nil),
+				evalSymlinks: mockEvalSymlinks(map[string]string{}),
+			}
+
+			result, err := detector.FindProjectRoot()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got result: %q", result)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("expected %q, got %q", tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
+// TestFindProjectRoot_FallbackToConfigFile tests fallback to walking up for config file
+func TestFindProjectRoot_FallbackToConfigFile(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	projectRoot := filepath.Join(tmpDir, "project")
+	nestedDir := filepath.Join(projectRoot, "apps", "web")
+
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatalf("failed to create test directories: %v", err)
+	}
+
+	// Create a config file at project root
+	configPath := filepath.Join(projectRoot, config.ConfigFileName)
+	if err := os.WriteFile(configPath, []byte("version: 1\nservices:\n  web:\n    path: apps/web\n"), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	// Test from nested directory
+	detector := &Detector{
+		gitCommand:   mockGitCommand("", fmt.Errorf("not a git repository")),
+		getwd:        mockGetwd(nestedDir, nil),
+		evalSymlinks: func(path string) (string, error) { return path, nil },
+	}
+
+	result, err := detector.FindProjectRoot()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The result should be the project root
+	if result != projectRoot {
+		t.Errorf("expected %q, got %q", projectRoot, result)
+	}
+}
+
+// TestFindProjectRoot_NotFound tests error when project root cannot be found
+func TestFindProjectRoot_NotFound(t *testing.T) {
+	// Create a temporary directory without any config
+	tmpDir := t.TempDir()
+
+	detector := &Detector{
+		gitCommand:   mockGitCommand("", fmt.Errorf("not a git repository")),
+		getwd:        mockGetwd(tmpDir, nil),
+		evalSymlinks: func(path string) (string, error) { return path, nil },
+	}
+
+	_, err := detector.FindProjectRoot()
+	if err != ErrProjectRootNotFound {
+		t.Errorf("expected ErrProjectRootNotFound, got: %v", err)
+	}
+}
+
+// TestIsWithinPath tests the path matching logic
+func TestIsWithinPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetPath string
+		basePath   string
+		expected   bool
+	}{
+		{
+			name:       "exact match",
+			targetPath: "/project/apps/web",
+			basePath:   "/project/apps/web",
+			expected:   true,
+		},
+		{
+			name:       "nested path",
+			targetPath: "/project/apps/web/src",
+			basePath:   "/project/apps/web",
+			expected:   true,
+		},
+		{
+			name:       "deeply nested",
+			targetPath: "/project/apps/web/src/components/Button.tsx",
+			basePath:   "/project/apps/web",
+			expected:   true,
+		},
+		{
+			name:       "not within - sibling",
+			targetPath: "/project/apps/api",
+			basePath:   "/project/apps/web",
+			expected:   false,
+		},
+		{
+			name:       "not within - similar name",
+			targetPath: "/project/apps/webapp",
+			basePath:   "/project/apps/web",
+			expected:   false,
+		},
+		{
+			name:       "not within - parent",
+			targetPath: "/project/apps",
+			basePath:   "/project/apps/web",
+			expected:   false,
+		},
+		{
+			name:       "not within - completely different",
+			targetPath: "/other/project",
+			basePath:   "/project/apps/web",
+			expected:   false,
+		},
+		{
+			name:       "with trailing slash",
+			targetPath: "/project/apps/web/",
+			basePath:   "/project/apps/web",
+			expected:   true,
+		},
+		{
+			name:       "with redundant slashes",
+			targetPath: "/project//apps///web",
+			basePath:   "/project/apps/web",
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isWithinPath(tt.targetPath, tt.basePath)
+			if result != tt.expected {
+				t.Errorf("isWithinPath(%q, %q) = %v, expected %v",
+					tt.targetPath, tt.basePath, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectService_ConvenienceFunction tests the package-level convenience function
+func TestDetectService_ConvenienceFunction(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"web": {Path: "apps/web"},
+		},
+	}
+
+	// This is more of an integration test
+	// We can't easily test it without real filesystem, so just ensure it doesn't panic
+	_, err := DetectService(cfg, "/nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent project root")
+	}
+}
+
+// TestDetectServiceWithRoot tests the convenience function that finds root and detects service
+func TestDetectServiceWithRoot(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	projectRoot := filepath.Join(tmpDir, "project")
+	webDir := filepath.Join(projectRoot, "apps", "web")
+
+	if err := os.MkdirAll(webDir, 0755); err != nil {
+		t.Fatalf("failed to create test directories: %v", err)
+	}
+
+	// Create a config file
+	configContent := `version: 1
+services:
+  web:
+    path: apps/web
+`
+	configPath := filepath.Join(projectRoot, config.ConfigFileName)
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	// Load config
+	cfg, err := config.LoadConfigFrom(configPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	// Create detector with mocked getwd
+	detector := &Detector{
+		gitCommand:   mockGitCommand("", fmt.Errorf("not a git repository")),
+		getwd:        mockGetwd(webDir, nil),
+		evalSymlinks: func(path string) (string, error) { return path, nil },
+	}
+
+	serviceName, err := detector.DetectService(cfg, projectRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if serviceName != "web" {
+		t.Errorf("expected service 'web', got %q", serviceName)
+	}
+
+	if projectRoot != projectRoot {
+		t.Errorf("expected root %q, got %q", projectRoot, projectRoot)
+	}
+}
+
+// TestDetectService_MultipleServices tests detection with multiple services
+func TestDetectService_MultipleServices(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Services: map[string]config.Service{
+			"web":     {Path: "apps/web"},
+			"api":     {Path: "apps/api"},
+			"worker":  {Path: "apps/worker"},
+			"admin":   {Path: "apps/admin"},
+			"mobile":  {Path: "mobile"},
+			"desktop": {Path: "desktop"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		cwd      string
+		expected string
+	}{
+		{name: "web service", cwd: "/project/apps/web/pages", expected: "web"},
+		{name: "api service", cwd: "/project/apps/api/routes", expected: "api"},
+		{name: "worker service", cwd: "/project/apps/worker", expected: "worker"},
+		{name: "admin service", cwd: "/project/apps/admin/dashboard", expected: "admin"},
+		{name: "mobile service", cwd: "/project/mobile/src", expected: "mobile"},
+		{name: "desktop service", cwd: "/project/desktop/main", expected: "desktop"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := &Detector{
+				gitCommand:   mockGitCommand("", fmt.Errorf("not used")),
+				getwd:        mockGetwd(tt.cwd, nil),
+				evalSymlinks: mockEvalSymlinks(map[string]string{}),
+			}
+
+			result, err := detector.DetectService(cfg, "/project")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Implements service detection and port calculation as specified in issues #7 and #8. These components work together to enable automatic port assignment.

This PR adds:
- Service detection from current working directory
- Port calculation using deterministic formula
- Integration with config, registry, and context packages
- Comprehensive test coverage (1,468 lines total)

## Service Detector (#7)

**Features:**
- `DetectService()` - Matches CWD against configured service paths
- `FindProjectRoot()` - Locates project root via git or config file
- Longest-match algorithm for nested service structures
- Symlink resolution for accurate path matching

**Error Handling:**
- Clear error when no service matches current directory
- Handles missing project root gracefully

## Port Calculator (#8)

**Features:**
- `CalculatePort()` - Calculates port using formula: `basePort + serviceIndex + 1`
- `CalculateAllPorts()` - Batch calculation for all services
- Deterministic alphabetical service ordering
- Example: basePort 4100 → api=4101, web=4102, worker=4103

**Error Handling:**
- Detects missing contexts in registry
- Detects missing services in config
- Wraps errors appropriately

## Test Coverage

**Service Detector Tests (578 lines, 13 test cases):**
- Basic service matching
- Nested service detection (longest path wins)
- Symlink resolution
- Project root detection (git + fallback)
- Error conditions
- Path matching edge cases

**Port Calculator Tests (586 lines, 17 test cases):**
- Port calculation formula verification
- Alphabetical ordering determinism
- Multiple projects and contexts
- Error handling
- Batch calculations
- Edge cases (single/many services)

All tests pass successfully.

## Integration

Integrates with existing packages:
- `internal/config` - for Config and Service structs
- `internal/registry` - for context basePort lookup
- `internal/context` - can be used alongside for full detection

## Files Changed
- `internal/service/detector.go` - Service detection (194 lines)
- `internal/service/detector_test.go` - Detector tests (578 lines)
- `internal/service/calculator.go` - Port calculation (110 lines)
- `internal/service/calculator_test.go` - Calculator tests (586 lines)

Closes #7
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)