### PR TITLE
feat: implement init, service add, and context create commands (#9, #10, #11)

### DIFF
--- a/cmd/dual/context.go
+++ b/cmd/dual/context.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/lightfastai/dual/internal/config"
+	"github.com/lightfastai/dual/internal/context"
+	"github.com/lightfastai/dual/internal/registry"
+	"github.com/spf13/cobra"
+)
+
+var (
+	basePort int
+)
+
+var contextCmd = &cobra.Command{
+	Use:   "context",
+	Short: "Manage development contexts",
+	Long:  `Create, list, or remove development contexts from the registry.`,
+}
+
+var contextCreateCmd = &cobra.Command{
+	Use:   "create [name]",
+	Short: "Create a new development context",
+	Long: `Create a new development context in the registry with the specified name and base port.
+
+If no name is provided, the context name will be auto-detected from the current git branch,
+or fall back to "default" if not in a git repository.
+
+If no base port is provided, an available port will be automatically assigned.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runContextCreate,
+}
+
+func init() {
+	contextCreateCmd.Flags().IntVar(&basePort, "base-port", 0, "Base port for the context (auto-assigned if not specified)")
+
+	contextCmd.AddCommand(contextCreateCmd)
+	rootCmd.AddCommand(contextCmd)
+}
+
+func runContextCreate(cmd *cobra.Command, args []string) error {
+	// Get or detect context name
+	var contextName string
+	if len(args) > 0 {
+		contextName = args[0]
+	} else {
+		// Auto-detect from git branch or use "default"
+		detectedContext, err := context.DetectContext()
+		if err != nil {
+			// If detection fails, use "default"
+			contextName = context.DefaultContext
+		} else {
+			contextName = detectedContext
+		}
+		fmt.Printf("[dual] Auto-detected context name: %s\n", contextName)
+	}
+
+	// Get project root - try git first, then config file
+	projectRoot, err := getProjectRoot()
+	if err != nil {
+		return fmt.Errorf("failed to determine project root: %w\nHint: Make sure you're in a git repository or have a dual.config.yml file", err)
+	}
+
+	// Load registry
+	reg, err := registry.LoadRegistry()
+	if err != nil {
+		return fmt.Errorf("failed to load registry: %w", err)
+	}
+
+	// Check if context already exists
+	if reg.ContextExists(projectRoot, contextName) {
+		existingContext, _ := reg.GetContext(projectRoot, contextName)
+		return fmt.Errorf("context %q already exists for this project with base port %d\nUse a different name or delete the existing context first", contextName, existingContext.BasePort)
+	}
+
+	// Auto-assign port if not specified
+	if basePort == 0 {
+		basePort = reg.FindNextAvailablePort()
+		fmt.Printf("[dual] Auto-assigned base port: %d\n", basePort)
+	}
+
+	// Validate base port
+	if basePort < 1024 || basePort > 65535 {
+		return fmt.Errorf("base port must be between 1024 and 65535, got %d", basePort)
+	}
+
+	// Get current path (for worktree support)
+	currentPath, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Set context in registry
+	if err := reg.SetContext(projectRoot, contextName, basePort, currentPath); err != nil {
+		return fmt.Errorf("failed to set context: %w", err)
+	}
+
+	// Save registry
+	if err := reg.SaveRegistry(); err != nil {
+		return fmt.Errorf("failed to save registry: %w", err)
+	}
+
+	fmt.Printf("[dual] Created context %q\n", contextName)
+	fmt.Printf("  Project: %s\n", projectRoot)
+	fmt.Printf("  Base Port: %d\n", basePort)
+	fmt.Println("\nServices will be assigned ports starting from:", basePort+1)
+
+	return nil
+}
+
+// getProjectRoot attempts to find the project root using git or config file
+func getProjectRoot() (string, error) {
+	// Try git first
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err == nil {
+		gitRoot := strings.TrimSpace(string(output))
+		if gitRoot != "" {
+			// Convert to absolute path
+			absPath, err := filepath.Abs(gitRoot)
+			if err == nil {
+				return absPath, nil
+			}
+		}
+	}
+
+	// Fall back to config file search
+	_, projectRoot, err := config.LoadConfig()
+	if err == nil {
+		return projectRoot, nil
+	}
+
+	return "", fmt.Errorf("could not determine project root via git or config file")
+}

--- a/cmd/dual/init.go
+++ b/cmd/dual/init.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/lightfastai/dual/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	forceInit bool
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a new dual configuration",
+	Long: `Creates a new dual.config.yml file in the current directory with an empty services configuration.
+
+If a configuration file already exists, use --force to overwrite it.`,
+	RunE: runInit,
+}
+
+func init() {
+	initCmd.Flags().BoolVar(&forceInit, "force", false, "Overwrite existing configuration file")
+	rootCmd.AddCommand(initCmd)
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	// Get current directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	configPath := filepath.Join(cwd, config.ConfigFileName)
+
+	// Check if config already exists
+	if _, err := os.Stat(configPath); err == nil {
+		if !forceInit {
+			return fmt.Errorf("configuration file already exists at %s\nUse --force to overwrite", configPath)
+		}
+		fmt.Printf("[dual] Overwriting existing configuration at %s\n", configPath)
+	}
+
+	// Create template config
+	templateConfig := &config.Config{
+		Version:  config.SupportedVersion,
+		Services: make(map[string]config.Service),
+	}
+
+	// Save the config
+	if err := config.SaveConfig(templateConfig, configPath); err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	fmt.Printf("[dual] Initialized configuration at %s\n", configPath)
+	fmt.Println("\nNext steps:")
+	fmt.Println("  1. Add services with: dual service add <name> --path <path>")
+	fmt.Println("  2. Create a context with: dual context create")
+	fmt.Println("  3. Run your commands with: dual <command>")
+
+	return nil
+}

--- a/cmd/dual/service.go
+++ b/cmd/dual/service.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/lightfastai/dual/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	servicePath    string
+	serviceEnvFile string
+)
+
+var serviceCmd = &cobra.Command{
+	Use:   "service",
+	Short: "Manage services in the dual configuration",
+	Long:  `Add, list, or remove services from the dual configuration.`,
+}
+
+var serviceAddCmd = &cobra.Command{
+	Use:   "add <name>",
+	Short: "Add a new service to the configuration",
+	Long: `Add a new service to the dual configuration with the specified name and path.
+
+The path should be relative to the project root (where dual.config.yml is located).
+Optionally, you can specify an env file for the service using --env-file.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runServiceAdd,
+}
+
+func init() {
+	serviceAddCmd.Flags().StringVar(&servicePath, "path", "", "Relative path to the service directory (required)")
+	serviceAddCmd.Flags().StringVar(&serviceEnvFile, "env-file", "", "Relative path to the env file for the service (optional)")
+	serviceAddCmd.MarkFlagRequired("path")
+
+	serviceCmd.AddCommand(serviceAddCmd)
+	rootCmd.AddCommand(serviceCmd)
+}
+
+func runServiceAdd(cmd *cobra.Command, args []string) error {
+	serviceName := args[0]
+
+	// Validate service name
+	if serviceName == "" {
+		return fmt.Errorf("service name cannot be empty")
+	}
+
+	// Load existing config
+	cfg, projectRoot, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w\nHint: Run 'dual init' to create a configuration file", err)
+	}
+
+	// Check if service already exists
+	if _, exists := cfg.Services[serviceName]; exists {
+		return fmt.Errorf("service %q already exists in the configuration", serviceName)
+	}
+
+	// Validate that the path is not absolute
+	if filepath.IsAbs(servicePath) {
+		return fmt.Errorf("path must be relative to project root, got absolute path: %s", servicePath)
+	}
+
+	// Validate that the path exists
+	fullPath := filepath.Join(projectRoot, servicePath)
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("path does not exist: %s (resolved to %s)", servicePath, fullPath)
+		}
+		return fmt.Errorf("failed to check path: %w", err)
+	}
+
+	// Validate that the path is a directory
+	if !info.IsDir() {
+		return fmt.Errorf("path must be a directory, got file: %s", servicePath)
+	}
+
+	// Validate env file if provided
+	if serviceEnvFile != "" {
+		if filepath.IsAbs(serviceEnvFile) {
+			return fmt.Errorf("env-file must be relative to project root, got absolute path: %s", serviceEnvFile)
+		}
+
+		// Check if the directory containing the env file exists
+		envFileFullPath := filepath.Join(projectRoot, serviceEnvFile)
+		envFileDir := filepath.Dir(envFileFullPath)
+		if _, err := os.Stat(envFileDir); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("env-file directory does not exist: %s (resolved to %s)", filepath.Dir(serviceEnvFile), envFileDir)
+			}
+			return fmt.Errorf("failed to check env-file directory: %w", err)
+		}
+	}
+
+	// Add service to config
+	cfg.Services[serviceName] = config.Service{
+		Path:    servicePath,
+		EnvFile: serviceEnvFile,
+	}
+
+	// Save the config
+	configPath := filepath.Join(projectRoot, config.ConfigFileName)
+	if err := config.SaveConfig(cfg, configPath); err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	fmt.Printf("[dual] Added service %q\n", serviceName)
+	fmt.Printf("  Path: %s\n", servicePath)
+	if serviceEnvFile != "" {
+		fmt.Printf("  Env File: %s\n", serviceEnvFile)
+	}
+
+	return nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -120,22 +120,20 @@ func TestValidateConfig(t *testing.T) {
 			errMsg:  "unsupported config version",
 		},
 		{
-			name: "no services",
+			name: "no services (allowed for init)",
 			config: &Config{
 				Version:  1,
 				Services: map[string]Service{},
 			},
-			wantErr: true,
-			errMsg:  "at least one service must be defined",
+			wantErr: false,
 		},
 		{
-			name: "nil services",
+			name: "nil services (allowed for init)",
 			config: &Config{
 				Version:  1,
 				Services: nil,
 			},
-			wantErr: true,
-			errMsg:  "at least one service must be defined",
+			wantErr: false,
 		},
 		{
 			name: "service with absolute path",
@@ -420,12 +418,11 @@ services:
 			errMsg:  "unsupported config version",
 		},
 		{
-			name: "missing services",
+			name: "missing services (allowed for init)",
 			content: `version: 1
 services: {}
 `,
-			wantErr: true,
-			errMsg:  "at least one service must be defined",
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
## Summary
Implements the three basic management commands for dual CLI as specified in issues #9, #10, and #11.

This PR adds:
- `dual init` - Initialize configuration
- `dual service add` - Register services
- `dual context create` - Create contexts with port assignments

## Commands Implemented

### `dual init` (#9)
Creates a template `dual.config.yml` file with version 1 and empty services.

**Usage:**
```bash
dual init                # Create new config
dual init --force        # Overwrite existing config
```

**Features:**
- ✅ Creates valid dual.config.yml
- ✅ Doesn't overwrite without --force
- ✅ Provides helpful next steps

### `dual service add` (#10)
Adds services to the configuration file.

**Usage:**
```bash
dual service add web --path apps/web
dual service add api --path apps/api --env-file .env.local
```

**Features:**
- ✅ Validates service names (prevents duplicates)
- ✅ Validates paths are relative and exist
- ✅ Validates env file directories exist
- ✅ Clear error messages

### `dual context create` (#11)
Creates contexts in the global registry with base port assignment.

**Usage:**
```bash
dual context create                           # Auto-detect name and port
dual context create main --base-port 4100     # Explicit name and port
dual context create feature-auth              # Explicit name, auto port
```

**Features:**
- ✅ Auto-detects context name from git branch
- ✅ Auto-assigns ports (4100, 4200, 4300, etc.)
- ✅ Validates port ranges (1024-65535)
- ✅ Prevents duplicate contexts
- ✅ Finds project root via git or config file

## Additional Changes

**Config Package Updates:**
- Added `SaveConfig()` function for atomic config file writing
- Updated validation to allow empty services (needed for `dual init`)
- Added test cases for empty services validation

**Integration:**
All commands integrate with existing packages:
- `internal/config` - for config file operations
- `internal/registry` - for context storage
- `internal/context` - for auto-detection

## Files Changed
- `cmd/dual/init.go` - Init command implementation
- `cmd/dual/service.go` - Service add command implementation
- `cmd/dual/context.go` - Context create command implementation
- `internal/config/config.go` - Added SaveConfig(), updated validation
- `internal/config/config_test.go` - Added empty services test cases

Closes #9
Closes #10
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)