### PR TITLE
fix: remove invalid fieldalignment setting from golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,8 +21,6 @@ linters-settings:
     enabled-checks:
       - elseif
       - exitAfterDefer
-  govet:
-    fieldalignment: 0  # Disable field alignment for test files
 
 issues:
   exclude-rules:


### PR DESCRIPTION
## Summary
Fixes golangci-lint config validation error in CI.

## Problem
The linting job was failing with:
```
jsonschema: "linters-settings.govet" does not validate with 
"/properties/linters-settings/properties/govet/additionalProperties": 
additional properties 'fieldalignment' not allowed
```

## Root Cause
The `.golangci.yml` file had:
```yaml
govet:
  fieldalignment: 0
```

But `fieldalignment` is not a valid setting for govet in golangci-lint. It's handled separately via the govet linter itself.

## Solution
Removed the invalid `govet` section with `fieldalignment` setting.

Field alignment warnings in test files are already properly handled by the `exclude-rules` section:
```yaml
issues:
  exclude-rules:
    - path: _test\.go
      linters:
        - govet  # Excludes ALL govet checks including field alignment
```

## Verification
```bash
$ golangci-lint config verify
✓ Config valid

$ golangci-lint run --timeout=5m
✓ All checks passed (only warnings about redundant gocritic checks)
```

## Files Changed
- `.golangci.yml` - Removed invalid govet.fieldalignment setting

This PR resolves the config validation error and allows the linting job to proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)