### PR TITLE
feat: enable npm package distribution

### DIFF
--- a/.changeset/icy-onions-sin.md
+++ b/.changeset/icy-onions-sin.md
@@ -1,0 +1,16 @@
+---
+"@lightfastai/dual": minor
+---
+
+Enable npm package distribution with automated multi-channel releases
+
+The dual CLI is now available via npm (`npm install -g @lightfastai/dual`) in addition to GitHub Releases and Homebrew. The npm wrapper automatically downloads the correct native binary for your platform during installation.
+
+This release also introduces fully automated release management using Changesets:
+- Automatic version bumping based on semantic versioning
+- Auto-generated CHANGELOGs from changeset descriptions
+- "Version Packages" PRs that preview all changes before release
+- One-click releases across GitHub, Homebrew, and npm
+- Post-release verification of all distribution channels
+
+Contributors can now document changes by running `npm run changeset` when making PRs. See CONTRIBUTING.md for the complete workflow.


### PR DESCRIPTION
## Summary

First release using the new automated changeset workflow! This PR introduces npm package distribution for dual.

## What's New

### npm Package Available

Users can now install dual via npm:
```bash
npm install -g @lightfastai/dual
```

The npm wrapper automatically downloads the correct native binary for the user's platform during installation.

### Automated Release Process

This changeset will trigger the new automated release workflow:
1. When this PR is merged → Changesets bot creates "Version Packages" PR
2. The Version Packages PR will show:
   - `npm/package.json` bumped from 0.1.0 → 0.2.0
   - `CHANGELOG.md` updated with this change
   - The changeset consumed
3. When Version Packages PR is merged → v0.2.0 release automatically triggers:
   - Binaries built and published to GitHub Releases
   - Homebrew formula updated
   - npm package published with provenance
   - All three channels verified

## Testing the Workflow

This PR is a test of the complete automated release infrastructure implemented in #61.

Expected behavior after merge:
- ✅ Changesets workflow runs
- ✅ "Version Packages" PR created automatically
- ✅ PR shows version bump 0.1.0 → 0.2.0
- ✅ CHANGELOG.md updated with changeset description

## Changeset Contents

```markdown
---
"@lightfastai/dual": minor
---

Enable npm package distribution with automated multi-channel releases

The dual CLI is now available via npm in addition to GitHub Releases and Homebrew.
Introduces fully automated release management using Changesets.
```

## Distribution Channels

After the Version Packages PR is merged, v0.2.0 will be available on:
- **GitHub Releases**: https://github.com/lightfastai/dual/releases/tag/v0.2.0
- **Homebrew**: `brew install lightfastai/tap/dual`
- **npm**: `npm install -g @lightfastai/dual`

Let's ship it! 🚀