### PR TITLE
fix: use PAT for tag push and make postinstall CI-aware

### DIFF
--- a/.github/workflows/tag-from-version.yml
+++ b/.github/workflows/tag-from-version.yml
@@ -54,3 +54,7 @@ jobs:
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin "v$VERSION"
           echo "✅ Created and pushed tag v$VERSION"
+        env:
+          # Use PAT to trigger downstream workflows (release.yml)
+          # Default GITHUB_TOKEN cannot trigger other workflows
+          GITHUB_TOKEN: ${{ secrets.LIGHTFAST_RELEASE_BOT_GITHUB_TOKEN }}

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -167,6 +167,15 @@ async function install() {
 
   console.log(`[dual] Installing for ${platform}-${arch}`);
 
+  // Skip download in CI environments where release may not exist yet
+  // This prevents failures during version bumping workflows
+  if (process.env.CI && !process.env.DUAL_FORCE_INSTALL) {
+    console.log('[dual] Detected CI environment - skipping binary download');
+    console.log('[dual] Binary will be available after release completes');
+    console.log('[dual] Set DUAL_FORCE_INSTALL=true to override this behavior');
+    return;
+  }
+
   // Check if binary already exists (useful for local development)
   if (fs.existsSync(binaryPath)) {
     console.log(`[dual] Binary already exists at ${binaryPath}`);


### PR DESCRIPTION
## Problem

The v0.2.0 release required manual intervention due to two issues:

1. **Workflow not triggered**: The `tag-from-version` workflow created the tag but the `release` workflow didn't trigger automatically
2. **Changesets workflow failed**: npm postinstall tried to download binaries from a release that didn't exist yet

## Root Cause

**Issue 1**: GitHub Actions limitation - workflows using `GITHUB_TOKEN` cannot trigger other workflows. The tag-from-version workflow used the default `GITHUB_TOKEN`, preventing the release workflow from running.

Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

**Issue 2**: Chicken-and-egg problem - postinstall.js runs during `npm install` in CI but tries to download binaries from GitHub Releases that don't exist yet.

## Solution

### Fix 1: Use PAT for Tag Push (Primary Fix)

Modified `.github/workflows/tag-from-version.yml` to use `LIGHTFAST_RELEASE_BOT_GITHUB_TOKEN` when pushing tags:

```yaml
- name: Create and push tag
  run: |
    git push origin "v$VERSION"
  env:
    GITHUB_TOKEN: ${{ secrets.LIGHTFAST_RELEASE_BOT_GITHUB_TOKEN }}
```

This allows the release workflow to be triggered automatically when tags are pushed.

### Fix 2: CI-Aware Postinstall (Defense-in-Depth)

Modified `npm/postinstall.js` to skip binary downloads in CI environments:

```javascript
// Skip download in CI environments where release may not exist yet
if (process.env.CI && !process.env.DUAL_FORCE_INSTALL) {
  console.log('[dual] Detected CI environment - skipping binary download');
  return;
}
```

Benefits:
- Prevents postinstall failures during version bump workflows
- Graceful handling with clear messaging
- Can be overridden with `DUAL_FORCE_INSTALL=true` if needed

## Expected Behavior After Merge

The complete automated flow will now work end-to-end:

```
1. Changeset PR merged
   ↓
2. Changesets workflow creates "Version Packages" PR
   ↓
3. Version Packages PR merged
   ↓
4. tag-from-version workflow creates tag (using PAT) ✨
   ↓
5. release workflow automatically triggers ✨
   ↓
6. Binaries built and published to GitHub Releases
   ↓
7. npm package published (postinstall skips in CI) ✨
   ↓
8. Homebrew formula updated
   ↓
9. All channels verified
```

## Testing Plan

After merging, test with v0.2.1 (or v0.3.0):

1. Create a changeset: `npm run changeset`
2. Merge the resulting Version Packages PR
3. Verify all workflows trigger automatically
4. Verify release completes on all three channels

## Changes

- `.github/workflows/tag-from-version.yml`: Use PAT for tag push
- `npm/postinstall.js`: Skip binary download in CI environments

## Recovery Status

✅ v0.2.0 was manually recovered and is live on all channels:
- GitHub: https://github.com/lightfastai/dual/releases/tag/v0.2.0
- npm: https://www.npmjs.com/package/@lightfastai/dual/v/0.2.0  
- Homebrew: Updated in tap

This PR prevents the issue from happening in future releases.