### PR TITLE
docs: add npm package badges to README

### DIFF
--- a/.changeset/fancy-tips-see.md
+++ b/.changeset/fancy-tips-see.md
@@ -1,0 +1,7 @@
+---
+"@lightfastai/dual": patch
+---
+
+Add npm package badges to README
+
+Display npm version and download count badges in the README to make npm installation more prominent and show package popularity.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **General-purpose port management for multi-context development**
 
+[![npm version](https://img.shields.io/npm/v/@lightfastai/dual)](https://www.npmjs.com/package/@lightfastai/dual)
+[![npm downloads](https://img.shields.io/npm/dm/@lightfastai/dual)](https://www.npmjs.com/package/@lightfastai/dual)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/lightfastai/dual)](https://go.dev/)
 [![Release](https://img.shields.io/github/v/release/lightfastai/dual)](https://github.com/lightfastai/dual/releases)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)


### PR DESCRIPTION
## Summary

Test of the complete automated release workflow with a patch release (v0.2.0 → v0.2.1).

## Changes

Added npm package badges to README to make npm installation more prominent:
- npm version badge
- npm downloads badge

## Testing the Automated Workflow

This PR tests the complete end-to-end flow after PR #64 fixes:

1. ✅ PR with changeset created
2. When merged → Changesets workflow will create "Version Packages" PR
3. When Version Packages merged → tag-from-version will create v0.2.1 tag **using PAT**
4. Tag creation will **automatically trigger** release workflow
5. Release workflow will publish to all three channels
6. Verification will confirm everything works

## Expected Outcome

After merging the Version Packages PR:
- **GitHub Release**: v0.2.1 with binaries
- **npm**: @lightfastai/dual@0.2.1
- **Homebrew**: Updated formula
- **CHANGELOG**: Automatically updated with this change

Let's watch the magic happen! ✨