### PR TITLE
feat: enhance error handling with actionable user guidance

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,7 +106,7 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "version field is required",
+			errMsg:  "Missing required 'version' field",
 		},
 		{
 			name: "unsupported version",
@@ -117,7 +117,7 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "unsupported config version",
+			errMsg:  "Unsupported config version",
 		},
 		{
 			name: "no services (allowed for init)",
@@ -219,7 +219,7 @@ func TestValidateService(t *testing.T) {
 				Path: "",
 			},
 			wantErr: true,
-			errMsg:  "path is required",
+			errMsg:  "missing required 'path' field",
 		},
 		{
 			name: "absolute path",
@@ -378,8 +378,8 @@ services:
 		if err == nil {
 			t.Error("LoadConfig() expected error, got nil")
 		}
-		if !contains(err.Error(), "no dual.config.yml found") {
-			t.Errorf("LoadConfig() error = %v, want error containing 'no dual.config.yml found'", err)
+		if !contains(err.Error(), "No dual.config.yml found") {
+			t.Errorf("LoadConfig() error = %v, want error containing 'No dual.config.yml found'", err)
 		}
 	})
 }
@@ -415,7 +415,7 @@ services:
     path: apps/web
 `,
 			wantErr: true,
-			errMsg:  "unsupported config version",
+			errMsg:  "Unsupported config version",
 		},
 		{
 			name: "missing services (allowed for init)",

--- a/test/integration/config_validation_test.go
+++ b/test/integration/config_validation_test.go
@@ -20,7 +20,7 @@ services: {}
 	// Try to use dual - should fail with version error
 	stdout, stderr, exitCode := h.RunDual("service", "add", "test", "--path", "apps/test")
 	h.AssertExitCode(exitCode, 1, stdout+stderr)
-	h.AssertOutputContains(stderr, "unsupported config version 99")
+	h.AssertOutputContains(stderr, "Unsupported config version 99")
 }
 
 // TestConfigValidationMissingVersion tests config validation with missing version
@@ -38,7 +38,7 @@ func TestConfigValidationMissingVersion(t *testing.T) {
 	// Try to use dual - should fail
 	stdout, stderr, exitCode := h.RunDual("service", "add", "test", "--path", "apps/test")
 	h.AssertExitCode(exitCode, 1, stdout+stderr)
-	h.AssertOutputContains(stderr, "version field is required")
+	h.AssertOutputContains(stderr, "Missing required 'version' field")
 }
 
 // TestConfigValidationAbsolutePath tests that absolute paths are rejected


### PR DESCRIPTION
## Summary

This PR significantly improves error handling throughout the dual CLI by replacing technical error messages with clear, actionable guidance that helps users quickly resolve issues.

### Problem
Users were encountering cryptic error messages like:
```
yaml: unmarshal errors: line 5: cannot unmarshal !!str `setup.sh` into []string  
```

This made it difficult to understand what went wrong and how to fix it, especially for the common case of incorrectly formatting hooks in `dual.config.yml`.

### Solution
Implemented comprehensive error handling improvements using the existing `internal/errors` package to provide structured errors with:
- Clear problem descriptions
- Contextual information (file paths, line numbers)
- Specific fix instructions
- Examples of correct usage

## Changes

### 🔧 Config Parsing (`internal/config/`)
- Detects YAML type mismatches (hooks as strings vs arrays)
- Shows correct YAML format with examples
- Provides helpful context for missing fields
- Enhanced path validation with full resolution

### 📦 Registry Operations (`internal/registry/`)
- Registry corruption now creates backups with recovery steps
- Lock timeouts show debugging commands and solutions
- Context not found errors list available contexts

### 🪝 Hook Execution (`internal/hooks/`)
- Script not found shows expected location
- Non-executable scripts get permission fix commands
- Execution failures include debug steps with env vars

### 🌳 Git Worktree (`cmd/dual/create.go`)
- Parses git stderr for common errors
- Provides specific solutions for each error type
- Shows valid branch naming rules when needed

## Example Improvements

**Before:**
```
failed to parse dual.config.yml: yaml: unmarshal errors:
  line 5: cannot unmarshal !!str `setup.sh` into []string
```

**After:**
```
Error: YAML parsing failed: hooks must be arrays, not strings
  Location: line 6
  File: dual.config.yml

How to fix:
  • Change hook configuration to use array format:
  
    Incorrect:  postWorktreeCreate: setup.sh
    Correct:    postWorktreeCreate:
                  - setup.sh
                  
  Multiple scripts example:
  postWorktreeCreate:
    - setup-database.sh
    - install-deps.sh
```

## Testing
- Tested YAML parsing errors with various misconfigurations
- Verified error messages display correctly with proper formatting
- Ensured backward compatibility maintained

## Impact
- ✅ Significantly improves user experience
- ✅ Reduces support burden 
- ✅ Makes dual more approachable for new users
- ✅ Helps users self-diagnose and fix issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)