### PR TITLE
feat: rust production readiness — thiserror, atomic state, tracing (DUAL-44)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,12 +164,16 @@ version = "1.3.0"
 dependencies = [
  "clap",
  "dirs",
+ "fs2",
  "http-body-util",
  "hyper",
  "hyper-util",
  "serde",
+ "thiserror",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -169,6 +182,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures-channel"
@@ -334,6 +357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +379,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +407,15 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -432,6 +485,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +544,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -527,6 +606,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -596,6 +684,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +772,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "want"
@@ -692,6 +847,28 @@ checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,16 @@ license = "MIT"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
+fs2 = "0.4"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["http1", "server", "client"] }
 hyper-util = { version = "0.1", features = ["tokio", "http1"] }
 serde = { version = "1", features = ["derive"] }
+thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 toml = "0.8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 uuid = { version = "1", features = ["v4"] }

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -98,36 +98,21 @@ pub fn build_clone_args(url: &str, branch: &str, target: &Path) -> Vec<String> {
     args
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CloneError {
+    #[error("git not found: {0}")]
     GitNotFound(String),
+
+    #[error("git clone failed for {repo}/{branch}: {stderr}")]
     GitFailed {
         repo: String,
         branch: String,
         stderr: String,
     },
+
+    #[error("filesystem error at {path}: {err}", path = .0.display(), err = .1)]
     Filesystem(PathBuf, std::io::Error),
 }
-
-impl std::fmt::Display for CloneError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CloneError::GitNotFound(err) => write!(f, "git not found: {err}"),
-            CloneError::GitFailed {
-                repo,
-                branch,
-                stderr,
-            } => {
-                write!(f, "git clone failed for {repo}/{branch}: {stderr}")
-            }
-            CloneError::Filesystem(path, err) => {
-                write!(f, "filesystem error at {}: {err}", path.display())
-            }
-        }
-    }
-}
-
-impl std::error::Error for CloneError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,32 +121,20 @@ pub fn decode_branch(encoded: &str) -> String {
     encoded.replace("__", "/")
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum HintsError {
+    #[error("Failed to read {path}: {err}", path = .0.display(), err = .1)]
     ReadError(PathBuf, std::io::Error),
+
+    #[error("Failed to write {path}: {err}", path = .0.display(), err = .1)]
     WriteError(PathBuf, std::io::Error),
+
+    #[error("Failed to parse {path}: {err}", path = .0.display(), err = .1)]
     ParseError(PathBuf, toml::de::Error),
+
+    #[error("Failed to serialize hints: {0}")]
     SerializeError(toml::ser::Error),
 }
-
-impl std::fmt::Display for HintsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            HintsError::ReadError(path, err) => {
-                write!(f, "Failed to read {}: {err}", path.display())
-            }
-            HintsError::WriteError(path, err) => {
-                write!(f, "Failed to write {}: {err}", path.display())
-            }
-            HintsError::ParseError(path, err) => {
-                write!(f, "Failed to parse {}: {err}", path.display())
-            }
-            HintsError::SerializeError(err) => write!(f, "Failed to serialize hints: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for HintsError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/container.rs
+++ b/src/container.rs
@@ -197,30 +197,18 @@ fn docker_simple(operation: &str, name: &str) -> Result<(), ContainerError> {
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ContainerError {
+    #[error("docker not found: {0}")]
     DockerNotFound(String),
+
+    #[error("docker {operation} failed for {name}: {stderr}")]
     Failed {
         operation: String,
         name: String,
         stderr: String,
     },
 }
-
-impl std::fmt::Display for ContainerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ContainerError::DockerNotFound(err) => write!(f, "docker not found: {err}"),
-            ContainerError::Failed {
-                operation,
-                name,
-                stderr,
-            } => write!(f, "docker {operation} failed for {name}: {stderr}"),
-        }
-    }
-}
-
-impl std::error::Error for ContainerError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -150,24 +150,14 @@ fn remove_recursive(path: &Path) -> Result<(), SharedError> {
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum SharedError {
+    #[error("Could not determine home directory")]
     NoHomeDir,
+
+    #[error("Filesystem error at {path}: {err}", path = .0.display(), err = .1)]
     Filesystem(PathBuf, std::io::Error),
 }
-
-impl std::fmt::Display for SharedError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SharedError::NoHomeDir => write!(f, "Could not determine home directory"),
-            SharedError::Filesystem(path, err) => {
-                write!(f, "Filesystem error at {}: {err}", path.display())
-            }
-        }
-    }
-}
-
-impl std::error::Error for SharedError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -147,30 +147,18 @@ fn tmux_simple(args: &[&str]) -> Result<(), TmuxError> {
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum TmuxError {
+    #[error("tmux not found: {0}")]
     NotFound(String),
+
+    #[error("tmux {operation} failed for {session}: {stderr}")]
     Failed {
         operation: String,
         session: String,
         stderr: String,
     },
 }
-
-impl std::fmt::Display for TmuxError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TmuxError::NotFound(err) => write!(f, "tmux not found: {err}"),
-            TmuxError::Failed {
-                operation,
-                session,
-                stderr,
-            } => write!(f, "tmux {operation} failed for {session}: {stderr}"),
-        }
-    }
-}
-
-impl std::error::Error for TmuxError {}
 
 #[cfg(test)]
 mod tests {

--- a/thoughts/shared/plans/2026-02-15-rust-production-readiness.md
+++ b/thoughts/shared/plans/2026-02-15-rust-production-readiness.md
@@ -1,0 +1,520 @@
+# Rust Production Readiness Implementation Plan
+
+## Overview
+
+Address three production readiness gaps identified in the [audit](../research/2026-02-15-rust-production-readiness-audit.md): error handling boilerplate, state file safety, and structured logging. These are independent improvements that can land as separate PRs.
+
+## Current State Analysis
+
+**Error handling**: 6 hand-rolled error enums across modules, each with manual `Display` and `Error` trait impls. ~150 lines of boilerplate. The pattern is correct but verbose. 5 `unwrap()` calls in `proxy.rs` on `Response::builder()` that are technically safe but look alarming in code review.
+
+**State persistence**: `state.rs:169` uses `std::fs::write()` which truncates-then-writes. If the process is killed mid-write, the state file is corrupted. No backup, no file locking.
+
+**Logging**: Only `println!`/`eprintln!` throughout. No debug/trace output for troubleshooting.
+
+### Key Discoveries:
+- `src/config.rs:124-149` — `HintsError` with 4 variants, 28 lines of manual Display
+- `src/state.rs:226-261` — `StateError` with 7 variants, 36 lines of manual Display
+- `src/container.rs:200-223` — `ContainerError` with 2 variants, 24 lines
+- `src/clone.rs:101-130` — `CloneError` with 3 variants, 30 lines
+- `src/tmux.rs:150-173` — `TmuxError` with 2 variants, 24 lines
+- `src/shared.rs:153-170` — `SharedError` with 2 variants, 18 lines
+- `src/proxy.rs:183,206,219,245,254` — 5 `unwrap()` calls on `Response::builder()`
+- `src/state.rs:160-171` — `save()` uses non-atomic `std::fs::write()`
+
+## Desired End State
+
+- All error enums use `thiserror` derive macros, eliminating manual `Display`/`Error` impls
+- Proxy response building uses a helper function with a documented `expect()` instead of scattered `unwrap()` calls
+- State file writes are atomic (write-to-temp-then-rename) with a `.bak` backup
+- Advisory file locking prevents concurrent state corruption
+- `tracing` provides structured logging with `DUAL_LOG` env var control
+- All existing tests continue to pass
+- `cargo clippy -- -D warnings` passes
+
+### How to verify:
+```bash
+cargo test               # All 108 tests pass
+cargo clippy -- -D warnings  # No warnings
+cargo fmt --check        # No formatting issues
+```
+
+## What We're NOT Doing
+
+- **Not changing the exit-code pattern in main.rs** — returning `i32` from `cmd_*` functions is appropriate for a CLI tool
+- **Not adopting `anyhow`** — the typed error enums are more appropriate for a library crate
+- **Not adding metrics/telemetry** — this is a local dev tool, not a server
+- **Not adding a daemon or hot-reload** — the proxy's immutable-state-at-startup pattern is fine
+- **Not changing the shell-out-over-SDK pattern** — this is a deliberate design choice
+
+## Implementation Approach
+
+Three independent phases, each landing as its own PR. Phase 1 is mechanical refactoring with no behavior change. Phase 2 adds safety to the most critical data path. Phase 3 adds observability.
+
+---
+
+## Phase 1: Error Handling Cleanup
+
+### Overview
+Replace hand-rolled error enums with `thiserror` derive macros. Extract a helper for proxy response building. Net reduction of ~100 lines of boilerplate with identical behavior.
+
+### Changes Required:
+
+#### 1. Add `thiserror` dependency
+**File**: `Cargo.toml`
+**Changes**: Add `thiserror` to dependencies
+
+```toml
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+dirs = "6"
+http-body-util = "0.1"
+hyper = { version = "1", features = ["http1", "server", "client"] }
+hyper-util = { version = "0.1", features = ["tokio", "http1"] }
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
+toml = "0.8"
+```
+
+#### 2. Convert `HintsError`
+**File**: `src/config.rs`
+**Changes**: Replace lines 124-149 with thiserror derive
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum HintsError {
+    #[error("Failed to read {}: {1}", .0.display())]
+    ReadError(PathBuf, #[source] std::io::Error),
+
+    #[error("Failed to write {}: {1}", .0.display())]
+    WriteError(PathBuf, #[source] std::io::Error),
+
+    #[error("Failed to parse {}: {1}", .0.display())]
+    ParseError(PathBuf, #[source] toml::de::Error),
+
+    #[error("Failed to serialize hints: {0}")]
+    SerializeError(#[source] toml::ser::Error),
+}
+```
+
+Removes: manual `Display` impl (lines 132-147) and `Error` impl (line 149).
+
+#### 3. Convert `StateError`
+**File**: `src/state.rs`
+**Changes**: Replace lines 226-261 with thiserror derive
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum StateError {
+    #[error("Could not determine home directory")]
+    NoHomeDir,
+
+    #[error("Failed to read {}: {1}", .0.display())]
+    ReadError(PathBuf, #[source] std::io::Error),
+
+    #[error("Failed to write {}: {1}", .0.display())]
+    WriteError(PathBuf, #[source] std::io::Error),
+
+    #[error("Failed to parse {}: {1}", .0.display())]
+    ParseError(PathBuf, #[source] toml::de::Error),
+
+    #[error("Failed to serialize state: {0}")]
+    SerializeError(#[source] toml::ser::Error),
+
+    #[error("Invalid state: {0}")]
+    Validation(String),
+
+    #[error("Workspace {0}/{1} already exists")]
+    DuplicateWorkspace(String, String),
+}
+```
+
+#### 4. Convert `ContainerError`
+**File**: `src/container.rs`
+**Changes**: Replace lines 200-223 with thiserror derive
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum ContainerError {
+    #[error("docker not found: {0}")]
+    DockerNotFound(String),
+
+    #[error("docker {operation} failed for {name}: {stderr}")]
+    Failed {
+        operation: String,
+        name: String,
+        stderr: String,
+    },
+}
+```
+
+#### 5. Convert `CloneError`
+**File**: `src/clone.rs`
+**Changes**: Replace lines 101-130 with thiserror derive
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum CloneError {
+    #[error("git not found: {0}")]
+    GitNotFound(String),
+
+    #[error("git clone failed for {repo}/{branch}: {stderr}")]
+    GitFailed {
+        repo: String,
+        branch: String,
+        stderr: String,
+    },
+
+    #[error("filesystem error at {}: {1}", .0.display())]
+    Filesystem(PathBuf, #[source] std::io::Error),
+}
+```
+
+#### 6. Convert `TmuxError`
+**File**: `src/tmux.rs`
+**Changes**: Replace lines 150-173 with thiserror derive
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum TmuxError {
+    #[error("tmux not found: {0}")]
+    NotFound(String),
+
+    #[error("tmux {operation} failed for {session}: {stderr}")]
+    Failed {
+        operation: String,
+        session: String,
+        stderr: String,
+    },
+}
+```
+
+#### 7. Convert `SharedError`
+**File**: `src/shared.rs`
+**Changes**: Replace lines 153-170 with thiserror derive
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum SharedError {
+    #[error("Could not determine home directory")]
+    NoHomeDir,
+
+    #[error("Filesystem error at {}: {1}", .0.display())]
+    Filesystem(PathBuf, #[source] std::io::Error),
+}
+```
+
+#### 8. Extract proxy response helper
+**File**: `src/proxy.rs`
+**Changes**: Add a helper function and replace 5 `unwrap()` sites
+
+Add after the imports (after line 15):
+
+```rust
+/// Build a 502 Bad Gateway response with a text body.
+fn bad_gateway(body: impl Into<String>) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(StatusCode::BAD_GATEWAY)
+        .body(Full::new(Bytes::from(body.into())))
+        .expect("valid status code always produces valid response")
+}
+```
+
+Replace each `Response::builder()...unwrap()` call:
+- Line 180-183: `return Ok(bad_gateway(body));`
+- Line 203-206: `return Ok(bad_gateway(body));`
+- Line 216-219: `return Ok(bad_gateway(body));`
+- Line 242-245: `Ok(bad_gateway(body))`
+- Line 251-254: `Ok(bad_gateway(body))`
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] All tests pass: `cargo test`
+- [x] No clippy warnings: `cargo clippy -- -D warnings`
+- [x] Formatting clean: `cargo fmt --check`
+- [x] Error messages unchanged (verify with `cargo test` — existing tests cover error Display output)
+
+#### Manual Verification:
+- [ ] `dual add` with invalid path shows same error message as before
+- [ ] `dual launch nonexistent` shows same error message as before
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation before proceeding to the next phase.
+
+---
+
+## Phase 2: State File Safety
+
+### Overview
+Make state file writes atomic to prevent corruption, keep a backup for recovery, and add advisory file locking to prevent concurrent access conflicts.
+
+### Changes Required:
+
+#### 1. Add `fs2` dependency
+**File**: `Cargo.toml`
+**Changes**: Add `fs2` for cross-platform advisory file locking
+
+```toml
+fs2 = "0.4"
+```
+
+#### 2. Implement atomic save with backup and locking
+**File**: `src/state.rs`
+**Changes**: Rewrite `save()` and `save_to()` functions (lines 160-183)
+
+```rust
+use fs2::FileExt;
+use std::fs::{self, File};
+use std::io::Write;
+
+/// Save state to default location. Uses atomic write with backup.
+pub fn save(state: &WorkspaceState) -> Result<(), StateError> {
+    let path = state_path().ok_or(StateError::NoHomeDir)?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| StateError::WriteError(parent.to_path_buf(), e))?;
+    }
+
+    atomic_save(state, &path)
+}
+
+/// Save state to a specific path. Uses atomic write with backup.
+pub fn save_to(state: &WorkspaceState, path: &Path) -> Result<(), StateError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| StateError::WriteError(parent.to_path_buf(), e))?;
+    }
+
+    atomic_save(state, path)
+}
+
+/// Atomic save: serialize → write to temp file → backup existing → rename.
+///
+/// Uses advisory file locking to prevent concurrent writes.
+/// The lock is held on the target file (or a lockfile) for the
+/// duration of the write-backup-rename sequence.
+fn atomic_save(state: &WorkspaceState, path: &Path) -> Result<(), StateError> {
+    let contents = toml::to_string_pretty(state).map_err(StateError::SerializeError)?;
+
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let lock_path = path.with_extension("lock");
+
+    // Acquire advisory lock
+    let lock_file = File::create(&lock_path)
+        .map_err(|e| StateError::WriteError(lock_path.clone(), e))?;
+    lock_file
+        .lock_exclusive()
+        .map_err(|e| StateError::WriteError(lock_path.clone(), e))?;
+
+    // Write to temp file in the same directory (same filesystem for rename)
+    let tmp_path = path.with_extension("tmp");
+    let mut tmp_file = File::create(&tmp_path)
+        .map_err(|e| StateError::WriteError(tmp_path.clone(), e))?;
+    tmp_file
+        .write_all(contents.as_bytes())
+        .map_err(|e| StateError::WriteError(tmp_path.clone(), e))?;
+    tmp_file
+        .sync_all()
+        .map_err(|e| StateError::WriteError(tmp_path.clone(), e))?;
+
+    // Backup existing file (best-effort — don't fail if original doesn't exist)
+    let bak_path = path.with_extension("toml.bak");
+    if path.exists() {
+        let _ = fs::copy(path, &bak_path);
+    }
+
+    // Atomic rename (POSIX guarantees this is atomic on same filesystem)
+    fs::rename(&tmp_path, path)
+        .map_err(|e| StateError::WriteError(path.to_path_buf(), e))?;
+
+    // Release lock (dropped with file, but explicit for clarity)
+    let _ = lock_file.unlock();
+    let _ = fs::remove_file(&lock_path);
+
+    Ok(())
+}
+```
+
+#### 3. Add `StateError` variant for lock failure (optional)
+**File**: `src/state.rs`
+**Changes**: The `WriteError` variant already covers lock file I/O errors. No new variant needed — lock failures are write errors on the lock path.
+
+#### 4. Update `save_to()` in tests
+**File**: `tests/` and `src/state.rs` tests
+**Changes**: No changes needed — `save_to()` signature is unchanged. Tests that use temp directories will now also create `.tmp` and `.lock` files, which are cleaned up.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] All tests pass: `cargo test`
+- [x] No clippy warnings: `cargo clippy -- -D warnings`
+- [x] Formatting clean: `cargo fmt --check`
+
+#### Manual Verification:
+- [ ] Run `dual add` in a real workspace — verify `~/.dual/workspaces.toml` is written correctly
+- [ ] Verify `~/.dual/workspaces.toml.bak` exists after a second save
+- [ ] Kill `dual add` mid-execution — verify state file is not corrupted
+- [ ] No stale `.lock` or `.tmp` files left after normal operation
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation before proceeding to the next phase.
+
+---
+
+## Phase 3: Structured Logging
+
+### Overview
+Replace `println!`/`eprintln!` with `tracing` macros. User-facing output uses `info!`/`warn!`/`error!` events. Debug-level output added at key decision points. Controlled via `DUAL_LOG` env var (default: `info`).
+
+### Changes Required:
+
+#### 1. Add `tracing` dependencies
+**File**: `Cargo.toml`
+**Changes**: Add tracing and tracing-subscriber
+
+```toml
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+```
+
+#### 2. Initialize tracing in main
+**File**: `src/main.rs`
+**Changes**: Add subscriber initialization at the top of `main()`
+
+```rust
+use tracing::{debug, error, info, warn};
+
+fn main() {
+    // Initialize tracing with DUAL_LOG env var (default: info)
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_env("DUAL_LOG")
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .without_time()
+        .with_target(false)
+        .init();
+
+    let cli = Cli::parse();
+    // ... rest unchanged
+```
+
+The `.without_time()` and `.with_target(false)` keep the output clean for a CLI tool — output looks like:
+```
+INFO  launching workspace myapp/main
+WARN  shared init failed: ...
+ERROR container start failed: ...
+```
+
+#### 3. Replace `println!` with `info!` in main.rs
+**File**: `src/main.rs`
+**Changes**: Replace user-facing status messages. Examples:
+
+- `println!("Added workspace...")` → `info!("Added workspace...")`
+- `println!("Launching...")` → `info!("Launching...")`
+- `println!("Destroyed...")` → `info!("Destroyed...")`
+
+#### 4. Replace `eprintln!("error: ...")` with `error!()` in main.rs
+**File**: `src/main.rs`
+**Changes**: Replace error messages. Examples:
+
+- `eprintln!("error: {e}")` → `error!("{e}")`
+- `eprintln!("error: unknown workspace '{}'")` → `error!("unknown workspace '{workspace}'")`
+
+#### 5. Replace `eprintln!("warning: ...")` with `warn!()` in main.rs
+**File**: `src/main.rs`
+**Changes**: Replace warning messages. Examples:
+
+- `eprintln!("warning: shared init failed: {e}")` → `warn!("shared init failed: {e}")`
+- `eprintln!("warning: container stop failed: {e}")` → `warn!("container stop failed: {e}")`
+
+#### 6. Replace `eprintln!` in proxy.rs with `warn!`/`error!`
+**File**: `src/proxy.rs`
+**Changes**: Replace the 3 eprintln calls:
+
+- `eprintln!("accept error on port {}: {e}")` → `warn!(port, "accept error: {e}")`
+- `eprintln!("connection error: {e}")` → (leave filtered silently as current behavior)
+- `eprintln!("backend connection error: {e}")` → `warn!("backend connection error: {e}")`
+
+#### 7. Add `debug!` at key decision points
+**File**: `src/main.rs` and module files
+**Changes**: Add debug-level traces at key points (only visible with `DUAL_LOG=debug`):
+
+```rust
+// In cmd_launch, after resolving workspace:
+debug!(repo = %entry.repo, branch = %entry.branch, "resolved workspace");
+
+// In container::create, before docker command:
+debug!(name, image, "creating container");
+
+// In proxy handle_request, on each request:
+debug!(host, port, "routing request");
+
+// In state::load, after successful load:
+debug!(count = state.workspaces.len(), "loaded state");
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] All tests pass: `cargo test`
+- [x] No clippy warnings: `cargo clippy -- -D warnings`
+- [x] Formatting clean: `cargo fmt --check`
+- [x] Binary size increase is reasonable (tracing adds ~200KB)
+
+#### Manual Verification:
+- [ ] `dual list` shows workspace list without log prefixes cluttering output (info level should look clean)
+- [ ] `DUAL_LOG=debug dual launch myapp` shows debug-level decision points
+- [ ] `DUAL_LOG=warn dual list` suppresses info-level status messages
+- [ ] Error messages still display correctly with the tracing format
+- [ ] Proxy shows connection info at debug level
+
+**Implementation Note**: The tracing format needs careful tuning to keep CLI output clean. The `without_time()` and `with_target(false)` options help, but the `INFO`/`WARN`/`ERROR` prefixes will be new. If the user prefers completely clean output at info level, consider using a custom formatter that omits the level prefix for `info!` events and only shows prefixes for `warn!`/`error!`.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- Error Display output tested by existing tests — thiserror must produce identical strings
+- State save/load roundtrip tests cover the atomic write path
+- No new unit tests needed for Phase 1 (behavior-preserving refactor)
+
+### Integration Tests:
+- E2E tests (`tests/e2e.rs`) exercise the full add/launch/destroy flow including state persistence
+- These tests will implicitly validate the atomic save and tracing initialization
+
+### Manual Testing Steps:
+1. Run `dual add` in a git repo — verify workspace is added and state file exists
+2. Run `dual launch <workspace>` — verify container starts and tmux session opens
+3. Run `dual destroy <workspace>` — verify clean teardown
+4. Check `~/.dual/workspaces.toml.bak` exists after multiple operations
+5. Run with `DUAL_LOG=debug` to see debug output
+6. Run with `DUAL_LOG=error` to suppress all info/warn output
+
+## Performance Considerations
+
+- `thiserror` is a proc-macro crate — adds compile time, zero runtime cost
+- `fs2` advisory locking adds one syscall per state save (negligible)
+- `tracing` adds ~200KB to binary size; runtime overhead is negligible for a CLI tool
+- Atomic save adds one extra file write + rename vs. direct write (negligible)
+
+## Dependencies Added
+
+| Crate | Version | Purpose | Maintenance |
+|-------|---------|---------|-------------|
+| `thiserror` | 2 | Error derive macros | dtolnay, widely used |
+| `fs2` | 0.4 | Cross-platform file locking | Stable, mature |
+| `tracing` | 0.1 | Structured logging framework | tokio-rs, ecosystem standard |
+| `tracing-subscriber` | 0.3 | Log output formatting | tokio-rs, ecosystem standard |
+
+Total new dependencies: 4 crates (all ecosystem staples).
+
+## References
+
+- Audit: `thoughts/shared/research/2026-02-15-rust-production-readiness-audit.md`
+- Architecture: `thoughts/ARCHITECTURE.md`
+- State module: `src/state.rs`
+- Proxy module: `src/proxy.rs`
+- Error enums: `src/config.rs:124`, `src/state.rs:226`, `src/container.rs:200`, `src/clone.rs:101`, `src/tmux.rs:150`, `src/shared.rs:153`

--- a/thoughts/shared/research/2026-02-15-rust-production-readiness-audit.md
+++ b/thoughts/shared/research/2026-02-15-rust-production-readiness-audit.md
@@ -1,0 +1,231 @@
+---
+date: 2026-02-15T12:00:00+08:00
+researcher: Claude
+git_commit: b96a25d0ab507fa63e96364ce246629fc0b0245a
+branch: main
+repository: dual
+topic: "Rust Production Readiness Audit"
+tags: [research, codebase, rust, production-readiness, error-handling, testing, safety]
+status: complete
+last_updated: 2026-02-15
+last_updated_by: Claude
+---
+
+# Research: Rust Production Readiness Audit
+
+**Date**: 2026-02-15T12:00:00+08:00
+**Researcher**: Claude
+**Git Commit**: b96a25d0ab507fa63e96364ce246629fc0b0245a
+**Branch**: main
+**Repository**: dual
+
+## Research Question
+Investigate the Rust implementation and assess production readiness across all critical dimensions: error handling, memory safety, concurrency, testing, dependency management, build/release pipeline, and operational concerns.
+
+## Summary
+
+Dual is a ~4,344-line Rust CLI tool (9 modules + main) that orchestrates terminal workspaces via Docker containers, tmux sessions, and git clones. The codebase is synchronous except for the reverse proxy (`proxy.rs`) which uses async tokio/hyper. The architecture is deliberately simple — shell out to `docker`/`tmux`/`git` CLIs rather than using SDK libraries. This is a **CLI tool, not a server or library**, which materially changes what "production readiness" means. Below is the audit across every major Rust production dimension.
+
+## Detailed Findings
+
+### 1. Error Handling
+
+**Current state:** Each module defines its own error enum (`HintsError`, `StateError`, `ContainerError`, `CloneError`, `TmuxError`, `SharedError`). All implement `Display` and `Error` traits. The main binary uses exit-code-based error handling (`-> i32` from each `cmd_*` function) with `eprintln!` for user-facing messages.
+
+**What exists:**
+- `src/config.rs:124-149` — `HintsError` enum with 4 variants
+- `src/state.rs:227-261` — `StateError` enum with 7 variants (most comprehensive)
+- `src/container.rs:200-223` — `ContainerError` enum with 2 variants
+- `src/clone.rs:101-130` — `CloneError` enum with 3 variants
+- `src/tmux.rs:150-173` — `TmuxError` enum with 2 variants
+- `src/shared.rs:153-170` — `SharedError` enum with 2 variants
+
+**Observations:**
+- No use of `anyhow` or `thiserror` — all error types are hand-rolled. This is valid but verbose.
+- The `main.rs` command functions return `i32` exit codes, not `Result`. Every error is handled at the call site with `eprintln!` + `return 1`. This works but there's no structured error propagation.
+- `unwrap()` usage is minimal and appears only in safe contexts:
+  - `main.rs:562` — `read_line().unwrap_or(0)` (fallback on stdin failure)
+  - `state.rs:54` — `dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))` (graceful fallback)
+- `.expect()` usage is confined to test code and the tokio runtime creation (`main.rs:464`).
+- `unwrap()` on `Response::builder()...body()` in `proxy.rs:183,203,244,253` — these are technically infallible since the builder is always valid, but they are still raw unwraps in async code.
+
+### 2. Memory Safety & Ownership
+
+**Current state:** The codebase follows Rust's ownership model correctly. No `unsafe` blocks exist anywhere.
+
+**What exists:**
+- All data is `Clone`-able where needed — workspace entries are cloned for mutation across functions
+- `Arc<ProxyState>` is used in `proxy.rs:87-137` for shared state across tokio tasks — correct usage
+- String ownership is clean — `to_string()` and `to_string_lossy()` are used at boundaries
+- No raw pointers, no transmute, no `unsafe`
+- `#[cfg(unix)]` / `#[cfg(windows)]` conditional compilation for symlink handling in `shared.rs:57-65`
+
+### 3. Concurrency & Async
+
+**Current state:** The codebase is almost entirely synchronous. Only `proxy.rs` uses async, and `main.rs:464` creates a tokio runtime with `Runtime::new()` + `block_on()` just for the proxy command.
+
+**What exists:**
+- `proxy.rs:75-148` — Async reverse proxy using hyper 1.x + tokio
+- `proxy.rs:107-137` — Spawns one tokio task per port, each with an accept loop spawning per-connection tasks
+- `proxy.rs:224-230` — Background connection driver task
+- The proxy state is built once at startup and is immutable (`Arc<ProxyState>`)
+- No mutexes, no RwLocks, no channels — the immutable-state-behind-Arc pattern avoids all lock contention
+
+**Observations:**
+- The proxy builds its route table once at startup from workspace state. It does not hot-reload when workspaces change. This is a design choice, not a bug.
+- Connection errors are silently filtered for "connection closed" messages (`proxy.rs:131-133`, `proxy.rs:225-229`)
+- The proxy fully buffers response bodies in memory (`body.collect().await` at `proxy.rs:238`) before forwarding. For a dev tool proxying to local containers this is fine.
+
+### 4. Testing
+
+**Current state:** 108 tests total — 74 lib unit tests, 14 main.rs tests, 10 harness smoke tests, 7 fixture smoke tests, 3 non-ignored e2e tests (+ 6 ignored Docker/tmux e2e tests).
+
+**What exists:**
+- Every module has inline `#[cfg(test)] mod tests` with coverage of core logic
+- `tests/harness/mod.rs` — RAII test fixture with `Drop`-based cleanup for Docker containers, tmux sessions, and temp directories
+- `tests/fixtures/mod.rs` — Creates minimal git repos for integration testing
+- `tests/e2e.rs` — Integration tests for clone, container lifecycle, bind mounts, network isolation, and tmux
+- E2E tests are `#[ignore]` by default, run separately with `--include-ignored`
+- CI runs e2e tests with Docker + tmux pre-installed (`.github/workflows/test.yml:62-105`)
+
+**Test categories:**
+- Unit: config parsing, branch encoding/decoding, container arg building, shell RC generation, subdomain extraction, proxy state resolution, state serialization roundtrips, validation
+- Integration: git clone operations, fixture repo creation
+- E2E: container lifecycle, exec exit codes, bind mounts, network isolation (same port different containers), tmux session lifecycle, tmux send-keys
+
+### 5. Dependency Management
+
+**Current state:** 7 runtime dependencies, 1 dev dependency.
+
+```
+clap 4        — CLI argument parsing (derive feature)
+dirs 6        — Home/config directory resolution
+http-body-util 0.1 — HTTP body utilities for hyper
+hyper 1       — HTTP server/client (http1 only)
+hyper-util 0.1 — Tokio integration for hyper
+serde 1       — Serialization (derive feature)
+tokio 1       — Async runtime (macros, rt-multi-thread, net)
+toml 0.8      — TOML config parsing
+
+[dev]
+uuid 1        — Test fixture unique IDs
+```
+
+**Observations:**
+- Dependency count is minimal (7 crates) for the functionality provided
+- All crates are well-maintained, widely-used ecosystem staples
+- `Cargo.lock` is presumably committed (standard for binaries)
+- No `[patch]` or git dependencies
+- `edition = "2024"` — uses the latest Rust edition
+- No `rust-toolchain.toml` — relies on user's installed stable toolchain
+
+### 6. Build & Release Pipeline
+
+**Current state:** Fully automated CI/CD via GitHub Actions.
+
+**What exists:**
+- `.github/workflows/test.yml` — CI pipeline with 3 jobs:
+  - `check`: `cargo fmt --check` + `cargo clippy -- -D warnings` + `cargo build`
+  - `unit-tests`: `cargo test`
+  - `e2e-tests`: Docker + tmux installed, pulls `node:20`, runs `cargo test --test e2e -- --include-ignored` with pre/post cleanup sweeps
+- `.github/workflows/release.yml` — Automated release via `cargo-dist` (v0.30.3)
+- `dist-workspace.toml` — Targets: `aarch64-apple-darwin`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`
+- Installers: shell script + PowerShell
+- Release profile: `inherits = "release"`, `lto = "thin"`
+- GitHub Releases with auto-generated artifacts
+
+### 7. Current Build Status
+
+**As of this audit:**
+- `cargo build` — succeeds
+- `cargo test` — 108 tests pass (6 ignored e2e tests requiring Docker/tmux)
+- `cargo clippy -- -D warnings` — **FAILS** with 3 `collapsible_if` warnings in `src/main.rs` (lines 104, 247, 248) — this is in uncommitted/staged changes
+- `cargo fmt --check` — **FAILS** with formatting diffs in `src/main.rs` (lines 249, 263)
+
+### 8. Logging & Observability
+
+**Current state:** No structured logging exists.
+
+**What exists:**
+- `println!` for user-facing status messages throughout `main.rs`
+- `eprintln!` for error messages
+- No `tracing`, `log`, or `env_logger` crate
+- No debug/trace-level output
+- No metrics collection
+
+### 9. Configuration & State Persistence
+
+**Current state:** TOML-based configuration and state.
+
+**What exists:**
+- State file: `~/.dual/workspaces.toml` (auto-created, read on every command)
+- Per-repo config: `.dual.toml` in workspace root
+- Shell RC files: `~/.config/dual/rc/{container_name}.sh`
+- Shared files: `~/.dual/shared/{repo}/`
+- State has validation (`state.rs:193-214`) — rejects empty repo, url, or branch fields
+- No file locking on state file reads/writes
+- No backup/recovery mechanism for corrupted state
+
+### 10. Security Considerations
+
+**What exists:**
+- Container names derived from user input (repo name + branch) — passed directly to `docker` CLI args
+- No shell injection vector — `Command::new("docker").args(...)` uses argument array, not shell string concatenation
+- Shell RC generation (`shell.rs:64-72`) embeds container name in shell function bodies — the container name comes from Dual's own naming convention (`dual-{repo}-{branch}`) which is sanitized via the encoding scheme
+- No network exposure — the proxy binds to `127.0.0.1` only (`proxy.rs:102`)
+- Docker containers use default bridge networking (no `--privileged`, no `--net=host`)
+- Bind mounts are workspace-dir-scoped only
+
+### 11. Platform Support
+
+**What exists:**
+- `#[cfg(target_os = "macos")]` and `#[cfg(target_os = "linux")]` for browser `open` command (`main.rs:409-413`)
+- `#[cfg(unix)]` and `#[cfg(windows)]` for symlink handling (`shared.rs:57-65`)
+- Build targets include all major platforms (macOS ARM/Intel, Linux ARM/Intel, Windows x64)
+- Windows support has the fallback of copying instead of symlinking
+
+### 12. Code Organization
+
+**What exists:**
+- 9 modules in `src/lib.rs`: `cli`, `clone`, `config`, `container`, `proxy`, `shared`, `shell`, `state`, `tmux`
+- Clear separation: each module handles one external system (Docker, tmux, git, filesystem, HTTP proxy)
+- `main.rs` is the orchestration layer — routes subcommands to `cmd_*` functions
+- No circular dependencies between modules
+- `config` is the shared utility module (workspace IDs, branch encoding, container naming)
+
+## Code References
+
+- `src/main.rs:14-31` — CLI dispatch
+- `src/main.rs:178-277` — `cmd_launch` (the core orchestration flow)
+- `src/lib.rs:1-9` — Module declarations
+- `src/config.rs:17-38` — `RepoHints` struct
+- `src/config.rs:93-122` — Workspace/container naming functions
+- `src/state.rs:10-116` — `WorkspaceState` and `WorkspaceEntry` with all methods
+- `src/state.rs:130-183` — State persistence (load/save with validation)
+- `src/container.rs:20-93` — Docker container management
+- `src/proxy.rs:75-148` — Async reverse proxy server
+- `src/proxy.rs:151-257` — HTTP request proxying logic
+- `src/shell.rs:37-55` — Shell RC generation
+- `src/tmux.rs:20-46` — Tmux session creation
+- `src/clone.rs:27-74` — Git clone workspace
+- `src/shared.rs:19-111` — Shared file propagation (init + copy)
+- `tests/harness/mod.rs:11-116` — RAII test harness
+- `tests/e2e.rs:76-304` — Docker/tmux integration tests
+
+## Architecture Documentation
+
+**Pattern: Shell-out over SDK.** Every external integration (Docker, tmux, git) uses `std::process::Command` to call the CLI binary rather than using Rust SDK crates. This keeps the dependency tree small and avoids binding to specific Docker API versions.
+
+**Pattern: Exit-code dispatch.** `main.rs` functions return `i32` exit codes rather than `Result<(), Error>`. Error messages are printed at the point of failure. This is a CLI-appropriate pattern.
+
+**Pattern: TOML state file.** The `~/.dual/workspaces.toml` file serves as both configuration and state. It's loaded fresh on every command invocation (no daemon, no caching).
+
+**Pattern: Immutable proxy state.** The reverse proxy builds its routing table once at startup and shares it via `Arc<ProxyState>`. No hot-reload, no locking needed.
+
+**Pattern: RAII test cleanup.** Test fixtures use Rust's `Drop` trait to clean up Docker containers, tmux sessions, and temp dirs — even on test panics.
+
+## Open Questions
+
+- The uncommitted changes in `main.rs` introduce clippy failures — is this work-in-progress?
+- No `Cargo.lock` was examined — is it committed as is standard for binary crates?
+- E2E tests require Docker and tmux — are they run on developer machines or only CI?


### PR DESCRIPTION
## Summary

Addresses three production readiness gaps identified in audit ([DUAL-44](https://linear.app/jps0000-dual/issue/DUAL-44)):

- **Error handling**: Replace 6 hand-rolled error enums (~107 lines of boilerplate) with `thiserror` derive macros. Extract `bad_gateway()` helper replacing 5 `unwrap()` calls in proxy.rs
- **State file safety**: Atomic writes (temp → sync → backup → rename) with advisory file locking via `fs2`
- **Structured logging**: Replace `println!`/`eprintln!` with `tracing` macros. `DUAL_LOG` env var control (default: `info`). Debug traces at key decision points

## Changes

| File | What changed |
|------|-------------|
| `Cargo.toml` | Added `thiserror`, `fs2`, `tracing`, `tracing-subscriber` |
| `src/{config,state,container,clone,tmux,shared}.rs` | Error enums → `thiserror` derive |
| `src/state.rs` | `save()`/`save_to()` → atomic write with lock + backup |
| `src/proxy.rs` | `bad_gateway()` helper, `tracing` macros |
| `src/main.rs` | Tracing init, all print macros → tracing macros |

## Test plan

- [x] All 115 tests pass (`cargo test`)
- [x] Zero clippy warnings (`cargo clippy -- -D warnings`)
- [x] Clean formatting (`cargo fmt --check`)
- [ ] `dual list` output looks clean at info level
- [ ] `DUAL_LOG=debug` shows decision point traces
- [ ] `DUAL_LOG=warn` suppresses info output
- [ ] State `.bak` file created after saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)