### PR TITLE
feat: add ratatui TUI workspace browser (DUAL-56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +92,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +159,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,11 +257,13 @@ name = "dual"
 version = "2.2.0"
 dependencies = [
  "clap",
+ "crossterm",
  "dirs",
  "fs2",
  "http-body-util",
  "hyper",
  "hyper-util",
+ "ratatui",
  "serde",
  "thiserror",
  "tokio",
@@ -178,10 +274,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fs2"
@@ -229,6 +347,17 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -325,13 +454,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -339,6 +496,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -379,10 +545,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "matchers"
@@ -406,6 +596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -436,6 +627,35 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -474,6 +694,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,10 +752,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -556,6 +831,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,10 +878,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -757,6 +1091,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,11 +1241,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -896,20 +1268,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -919,9 +1313,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -931,9 +1337,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -943,15 +1361,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+crossterm = "0.28"
 dirs = "6"
 fs2 = "0.4"
 http-body-util = "0.1"
@@ -15,6 +16,7 @@ hyper = { version = "1", features = ["http1", "server", "client"] }
 hyper-util = { version = "0.1", features = ["tokio", "http1"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+ratatui = "0.29"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 toml = "0.8"
 tracing = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod shared;
 pub mod shell;
 pub mod state;
 pub mod tmux_backend;
+pub mod tui;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,0 +1,365 @@
+use crate::backend::MultiplexerBackend;
+use crate::clone;
+use crate::config;
+use crate::container;
+use crate::state::WorkspaceState;
+
+use super::event;
+use super::ui;
+
+/// A single item in the flattened display list.
+pub struct DisplayItem {
+    /// Text to show
+    pub display: String,
+    /// Workspace status (None = repo header)
+    pub status: Option<WorkspaceStatus>,
+    /// Workspace id if this is a branch item
+    pub workspace_id: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+pub enum WorkspaceStatus {
+    /// tmux session alive
+    Running,
+    /// Container stopped, no tmux
+    Stopped,
+    /// Not cloned yet
+    Lazy,
+}
+
+struct RepoGroup {
+    name: String,
+    workspaces: Vec<WorkspaceItem>,
+    expanded: bool,
+}
+
+struct WorkspaceItem {
+    branch: String,
+    workspace_id: String,
+    status: WorkspaceStatus,
+}
+
+pub struct App {
+    repos: Vec<RepoGroup>,
+    selected: usize,
+    item_count: usize,
+}
+
+impl App {
+    /// Build app state from workspace state and live backend status.
+    pub fn new(state: &WorkspaceState, backend: &dyn MultiplexerBackend) -> Self {
+        let workspace_root = state.workspace_root();
+
+        // Group workspaces by repo (preserve insertion order)
+        let mut repo_names: Vec<String> = Vec::new();
+        for ws in state.all_workspaces() {
+            if !repo_names.contains(&ws.repo) {
+                repo_names.push(ws.repo.clone());
+            }
+        }
+
+        let repos: Vec<RepoGroup> = repo_names
+            .iter()
+            .map(|repo| {
+                let workspaces = state
+                    .workspaces_for_repo(repo)
+                    .into_iter()
+                    .map(|ws| {
+                        let session_name = config::session_name(&ws.repo, &ws.branch);
+                        let container_name = config::container_name(&ws.repo, &ws.branch);
+                        let clone_exists = if ws.path.is_some() {
+                            ws.path
+                                .as_ref()
+                                .is_some_and(|p| std::path::PathBuf::from(p).join(".git").exists())
+                        } else {
+                            clone::workspace_exists(&workspace_root, &ws.repo, &ws.branch)
+                        };
+
+                        let status = if backend.is_alive(&session_name) {
+                            WorkspaceStatus::Running
+                        } else if matches!(
+                            container::status(&container_name),
+                            container::ContainerStatus::Stopped
+                        ) || clone_exists
+                        {
+                            WorkspaceStatus::Stopped
+                        } else {
+                            WorkspaceStatus::Lazy
+                        };
+
+                        WorkspaceItem {
+                            branch: ws.branch.clone(),
+                            workspace_id: config::workspace_id(&ws.repo, &ws.branch),
+                            status,
+                        }
+                    })
+                    .collect();
+
+                RepoGroup {
+                    name: repo.clone(),
+                    workspaces,
+                    expanded: true,
+                }
+            })
+            .collect();
+
+        let item_count = Self::count_items(&repos);
+        App {
+            repos,
+            selected: 0,
+            item_count,
+        }
+    }
+
+    fn count_items(repos: &[RepoGroup]) -> usize {
+        repos
+            .iter()
+            .map(|r| 1 + if r.expanded { r.workspaces.len() } else { 0 })
+            .sum()
+    }
+
+    /// Flatten repos into display items for rendering.
+    pub fn flatten_items(&self) -> Vec<DisplayItem> {
+        let mut items = Vec::new();
+        for repo in &self.repos {
+            let chevron = if repo.expanded { "▼" } else { "▶" };
+            items.push(DisplayItem {
+                display: format!("{chevron} {}", repo.name),
+                status: None,
+                workspace_id: None,
+            });
+            if repo.expanded {
+                for ws in &repo.workspaces {
+                    let icon = match ws.status {
+                        WorkspaceStatus::Running => "●",
+                        WorkspaceStatus::Stopped => "○",
+                        WorkspaceStatus::Lazy => "◌",
+                    };
+                    let label = match ws.status {
+                        WorkspaceStatus::Running => "running",
+                        WorkspaceStatus::Stopped => "stopped",
+                        WorkspaceStatus::Lazy => "lazy",
+                    };
+                    let branch_display = config::decode_branch(&config::encode_branch(&ws.branch));
+                    items.push(DisplayItem {
+                        display: format!("  {branch_display:<24} {icon} {label}"),
+                        status: Some(ws.status),
+                        workspace_id: Some(ws.workspace_id.clone()),
+                    });
+                }
+            }
+        }
+        items
+    }
+
+    pub fn selected(&self) -> usize {
+        self.selected
+    }
+
+    pub fn move_down(&mut self) {
+        if self.selected + 1 < self.item_count {
+            self.selected += 1;
+        }
+    }
+
+    pub fn move_up(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Get the workspace_id of the currently selected item, or None if it's a repo header.
+    pub fn selected_workspace_id(&self) -> Option<String> {
+        let items = self.flatten_items();
+        items
+            .get(self.selected)
+            .and_then(|item| item.workspace_id.clone())
+    }
+
+    /// Toggle expand/collapse of the repo group at the current selection.
+    pub fn toggle_expand(&mut self) {
+        // Find which repo group this index belongs to
+        let mut idx = 0;
+        for repo in &mut self.repos {
+            if idx == self.selected {
+                repo.expanded = !repo.expanded;
+                self.item_count = Self::count_items_from_repos(&self.repos);
+                // Clamp selected if it now exceeds item count
+                if self.selected >= self.item_count {
+                    self.selected = self.item_count.saturating_sub(1);
+                }
+                return;
+            }
+            idx += 1;
+            if repo.expanded {
+                idx += repo.workspaces.len();
+            }
+        }
+    }
+
+    fn count_items_from_repos(repos: &[RepoGroup]) -> usize {
+        Self::count_items(repos)
+    }
+}
+
+/// Main TUI entry point.
+///
+/// Returns `Ok(Some(workspace_id))` if user selected a workspace to launch.
+/// Returns `Ok(None)` if user quit.
+pub fn run(
+    state: &WorkspaceState,
+    backend: &dyn MultiplexerBackend,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let mut terminal = ratatui::init();
+    let mut app = App::new(state, backend);
+
+    let result = loop {
+        terminal.draw(|frame| ui::render(frame, &app))?;
+
+        if let Some(action) = event::handle_events(&mut app)? {
+            match action {
+                event::Action::Quit => break Ok(None),
+                event::Action::Select(workspace_id) => {
+                    break Ok(Some(workspace_id));
+                }
+            }
+        }
+    };
+
+    ratatui::restore();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{WorkspaceEntry, WorkspaceState};
+    use crate::tmux_backend::TmuxBackend;
+
+    fn test_state() -> WorkspaceState {
+        let mut state = WorkspaceState::new();
+        state
+            .add_workspace(WorkspaceEntry {
+                repo: "lightfast".into(),
+                url: "url".into(),
+                branch: "main".into(),
+                path: None,
+            })
+            .unwrap();
+        state
+            .add_workspace(WorkspaceEntry {
+                repo: "lightfast".into(),
+                url: "url".into(),
+                branch: "feat/auth".into(),
+                path: None,
+            })
+            .unwrap();
+        state
+            .add_workspace(WorkspaceEntry {
+                repo: "agent-os".into(),
+                url: "url".into(),
+                branch: "main".into(),
+                path: None,
+            })
+            .unwrap();
+        state
+    }
+
+    #[test]
+    fn app_groups_by_repo() {
+        let state = test_state();
+        let backend = TmuxBackend::new();
+        let app = App::new(&state, &backend);
+
+        assert_eq!(app.repos.len(), 2);
+        assert_eq!(app.repos[0].name, "lightfast");
+        assert_eq!(app.repos[0].workspaces.len(), 2);
+        assert_eq!(app.repos[1].name, "agent-os");
+        assert_eq!(app.repos[1].workspaces.len(), 1);
+    }
+
+    #[test]
+    fn flatten_items_expanded() {
+        let state = test_state();
+        let backend = TmuxBackend::new();
+        let app = App::new(&state, &backend);
+        let items = app.flatten_items();
+
+        // 2 repo headers + 3 workspaces = 5
+        assert_eq!(items.len(), 5);
+        assert!(items[0].status.is_none()); // repo header
+        assert!(items[0].display.contains("lightfast"));
+        assert!(items[1].status.is_some()); // workspace
+        assert!(items[1].display.contains("main"));
+        assert!(items[3].status.is_none()); // repo header
+        assert!(items[3].display.contains("agent-os"));
+    }
+
+    #[test]
+    fn navigation_bounds() {
+        let state = test_state();
+        let backend = TmuxBackend::new();
+        let mut app = App::new(&state, &backend);
+
+        assert_eq!(app.selected(), 0);
+        app.move_up(); // should stay at 0
+        assert_eq!(app.selected(), 0);
+
+        // Move to the end
+        for _ in 0..10 {
+            app.move_down();
+        }
+        assert_eq!(app.selected(), 4); // 5 items, max index = 4
+    }
+
+    #[test]
+    fn selected_workspace_id_returns_none_for_header() {
+        let state = test_state();
+        let backend = TmuxBackend::new();
+        let app = App::new(&state, &backend);
+        // First item is a repo header
+        assert!(app.selected_workspace_id().is_none());
+    }
+
+    #[test]
+    fn selected_workspace_id_returns_id_for_branch() {
+        let state = test_state();
+        let backend = TmuxBackend::new();
+        let mut app = App::new(&state, &backend);
+        app.move_down(); // move to first workspace
+        assert_eq!(
+            app.selected_workspace_id(),
+            Some("lightfast-main".to_string())
+        );
+    }
+
+    #[test]
+    fn toggle_collapse_reduces_items() {
+        let state = test_state();
+        let backend = TmuxBackend::new();
+        let mut app = App::new(&state, &backend);
+
+        assert_eq!(app.item_count, 5);
+        app.toggle_expand(); // collapse "lightfast"
+        assert_eq!(app.item_count, 3); // 2 headers + 1 workspace (agent-os/main)
+    }
+
+    #[test]
+    fn toggle_expand_restores_items() {
+        let state = test_state();
+        let backend = TmuxBackend::new();
+        let mut app = App::new(&state, &backend);
+
+        app.toggle_expand(); // collapse
+        assert_eq!(app.item_count, 3);
+        app.toggle_expand(); // expand again
+        assert_eq!(app.item_count, 5);
+    }
+
+    #[test]
+    fn empty_state_produces_no_items() {
+        let state = WorkspaceState::new();
+        let backend = TmuxBackend::new();
+        let app = App::new(&state, &backend);
+        assert_eq!(app.flatten_items().len(), 0);
+        assert_eq!(app.item_count, 0);
+    }
+}

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,0 +1,129 @@
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
+
+use super::app::App;
+
+pub enum Action {
+    Quit,
+    Select(String), // workspace_id
+}
+
+pub fn handle_events(app: &mut App) -> Result<Option<Action>, Box<dyn std::error::Error>> {
+    if event::poll(std::time::Duration::from_millis(100))?
+        && let Event::Key(key) = event::read()?
+        && key.kind == KeyEventKind::Press
+    {
+        return Ok(handle_key(app, key));
+    }
+    Ok(None)
+}
+
+fn handle_key(app: &mut App, key: KeyEvent) -> Option<Action> {
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => Some(Action::Quit),
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.move_up();
+            None
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            app.move_down();
+            None
+        }
+        KeyCode::Enter => {
+            if let Some(workspace_id) = app.selected_workspace_id() {
+                Some(Action::Select(workspace_id))
+            } else {
+                // Selected a repo header — toggle expand/collapse
+                app.toggle_expand();
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn make_app() -> App {
+        use crate::state::{WorkspaceEntry, WorkspaceState};
+        use crate::tmux_backend::TmuxBackend;
+
+        let mut state = WorkspaceState::new();
+        state
+            .add_workspace(WorkspaceEntry {
+                repo: "lightfast".into(),
+                url: "url".into(),
+                branch: "main".into(),
+                path: None,
+            })
+            .unwrap();
+        state
+            .add_workspace(WorkspaceEntry {
+                repo: "lightfast".into(),
+                url: "url".into(),
+                branch: "feat/auth".into(),
+                path: None,
+            })
+            .unwrap();
+
+        let backend = TmuxBackend::new();
+        App::new(&state, &backend)
+    }
+
+    #[test]
+    fn quit_on_q() {
+        let mut app = make_app();
+        let action = handle_key(&mut app, key(KeyCode::Char('q')));
+        assert!(matches!(action, Some(Action::Quit)));
+    }
+
+    #[test]
+    fn quit_on_esc() {
+        let mut app = make_app();
+        let action = handle_key(&mut app, key(KeyCode::Esc));
+        assert!(matches!(action, Some(Action::Quit)));
+    }
+
+    #[test]
+    fn navigate_down() {
+        let mut app = make_app();
+        let initial = app.selected();
+        handle_key(&mut app, key(KeyCode::Down));
+        assert_eq!(app.selected(), initial + 1);
+    }
+
+    #[test]
+    fn navigate_up_at_top() {
+        let mut app = make_app();
+        handle_key(&mut app, key(KeyCode::Up));
+        assert_eq!(app.selected(), 0);
+    }
+
+    #[test]
+    fn enter_on_repo_header_toggles() {
+        let mut app = make_app();
+        // First item should be a repo header
+        let action = handle_key(&mut app, key(KeyCode::Enter));
+        assert!(action.is_none()); // toggle, not select
+    }
+
+    #[test]
+    fn j_and_k_navigate() {
+        let mut app = make_app();
+        handle_key(&mut app, key(KeyCode::Char('j')));
+        assert_eq!(app.selected(), 1);
+        handle_key(&mut app, key(KeyCode::Char('k')));
+        assert_eq!(app.selected(), 0);
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,5 @@
+mod app;
+mod event;
+mod ui;
+
+pub use app::run;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,0 +1,137 @@
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+
+use super::app::{App, WorkspaceStatus};
+
+pub fn render(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+
+    let chunks = Layout::vertical([
+        Constraint::Length(1), // header
+        Constraint::Min(3),    // workspace list
+        Constraint::Length(1), // footer
+    ])
+    .split(area);
+
+    // Header
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(" dual", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw("  workspace browser"),
+    ]));
+    frame.render_widget(header, chunks[0]);
+
+    // Workspace list
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let items = app.flatten_items();
+
+    if items.is_empty() {
+        let empty = Paragraph::new("  No workspaces. Run `dual add` in a repo to get started.")
+            .block(block);
+        frame.render_widget(empty, chunks[1]);
+    } else {
+        let list_items: Vec<ListItem> = items
+            .iter()
+            .map(|item| {
+                let style = match item.status {
+                    Some(WorkspaceStatus::Running) => Style::default().fg(Color::Green),
+                    Some(WorkspaceStatus::Stopped) => Style::default().fg(Color::Yellow),
+                    Some(WorkspaceStatus::Lazy) => Style::default().fg(Color::DarkGray),
+                    None => Style::default().add_modifier(Modifier::BOLD), // repo header
+                };
+                ListItem::new(Line::from(Span::styled(&item.display, style)))
+            })
+            .collect();
+
+        let list = List::new(list_items)
+            .block(block)
+            .highlight_style(
+                Style::default()
+                    .add_modifier(Modifier::REVERSED)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("▸ ");
+
+        let mut list_state = ListState::default();
+        list_state.select(Some(app.selected()));
+
+        frame.render_stateful_widget(list, chunks[1], &mut list_state);
+    }
+
+    // Footer keybindings
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled(" j/k", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" navigate  "),
+        Span::styled("enter", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" launch  "),
+        Span::styled("q", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" quit"),
+    ]))
+    .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(footer, chunks[2]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{WorkspaceEntry, WorkspaceState};
+    use crate::tmux_backend::TmuxBackend;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    #[test]
+    fn render_does_not_panic_empty() {
+        let state = WorkspaceState::new();
+        let backend = TmuxBackend::new();
+        let app = App::new(&state, &backend);
+
+        let test_backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(test_backend).unwrap();
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+    }
+
+    #[test]
+    fn render_does_not_panic_with_workspaces() {
+        let mut state = WorkspaceState::new();
+        state
+            .add_workspace(WorkspaceEntry {
+                repo: "lightfast".into(),
+                url: "url".into(),
+                branch: "main".into(),
+                path: None,
+            })
+            .unwrap();
+
+        let backend = TmuxBackend::new();
+        let app = App::new(&state, &backend);
+
+        let test_backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(test_backend).unwrap();
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+    }
+
+    #[test]
+    fn render_does_not_panic_small_terminal() {
+        let mut state = WorkspaceState::new();
+        state
+            .add_workspace(WorkspaceEntry {
+                repo: "lightfast".into(),
+                url: "url".into(),
+                branch: "main".into(),
+                path: None,
+            })
+            .unwrap();
+
+        let backend = TmuxBackend::new();
+        let app = App::new(&state, &backend);
+
+        let test_backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(test_backend).unwrap();
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ratatui` + `crossterm` dependencies
- Create `src/tui/` module with tree view of repos/branches grouped by repo
- `dual` (no args) now launches the TUI workspace browser
- `dual list` remains as non-interactive fallback
- Navigation: `j`/`k` or arrow keys, `Enter` to launch, `q`/`Esc` to quit
- Repo headers expand/collapse with `Enter`
- Status indicators: `●` running, `○` stopped, `◌` lazy

**Depends on**: #135 (DUAL-55 — MultiplexerBackend trait)

Resolves DUAL-56

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all 148 tests pass (109 lib + 19 main + 3 e2e + 7 fixture + 10 harness)
- [x] 17 new TUI unit tests (app state, navigation, rendering, event handling)
- [ ] `dual` shows TUI with repos and branches listed
- [ ] Arrow keys / j/k navigate the list
- [ ] Enter on repo header toggles expand/collapse
- [ ] Enter on branch launches workspace
- [ ] `q` exits cleanly (terminal restored properly)
- [ ] `dual list` still works as non-interactive output