### PR TITLE
Add dev container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
+
+# Dual requires tmux for terminal multiplexing
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tmux \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "Dual",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "CARGO_TERM_COLOR": "always"
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-fetch cargo dependencies so first build is faster
+cargo fetch
+
+# Install clippy and rustfmt (may already be present in base image)
+rustup component add clippy rustfmt 2>/dev/null || true
+
+# Pull the default test image used by E2E tests and .dual.toml
+docker pull node:20 || echo "warn: docker pull failed — E2E tests will pull on first run"


### PR DESCRIPTION
Adopts the dev container standard for replicable development
environments. Uses the official Rust base image with Docker-in-Docker
and Node 20 features so the full test suite (including E2E tests that
shell out to Docker and tmux) can run inside the container.

https://claude.ai/code/session_01SqwVZKfdw9j6UuGJdTv3kU